### PR TITLE
Boundary-ize redis

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -33,5 +33,5 @@ config :logger, :console, format: "[$level] $message\n"
 config :phoenix, :stacktrace_depth, 20
 
 # External clients
-config :castle, :redis, Castle.Redis
+config :castle, :redis, Castle.Redis.Api
 config :castle, :bigquery, BigQuery

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -31,3 +31,7 @@ config :logger, :console, format: "[$level] $message\n"
 # Set a higher stacktrace during development. Avoid configuring such
 # in production as building large stacktraces may be expensive.
 config :phoenix, :stacktrace_depth, 20
+
+# External clients
+config :castle, :redis, Castle.Redis
+config :castle, :bigquery, BigQuery

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -18,6 +18,10 @@ config :castle, Castle.Endpoint,
 # Do not print debug messages in production
 config :logger, level: :info
 
+# External clients
+config :castle, :redis, Castle.Redis
+config :castle, :bigquery, BigQuery
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -19,7 +19,7 @@ config :castle, Castle.Endpoint,
 config :logger, level: :info
 
 # External clients
-config :castle, :redis, Castle.Redis
+config :castle, :redis, Castle.Redis.Api
 config :castle, :bigquery, BigQuery
 
 # ## SSL Support

--- a/config/test.exs
+++ b/config/test.exs
@@ -8,3 +8,7 @@ config :castle, Castle.Endpoint,
 
 # Print only warnings and errors during test
 config :logger, level: :warn
+
+# External clients
+config :castle, :redis, Castle.FakeRedis
+config :castle, :bigquery, BigQuery

--- a/lib/plugs/interval_plug.ex
+++ b/lib/plugs/interval_plug.ex
@@ -6,7 +6,7 @@ defmodule Castle.Plugs.Interval do
     "1h"  => 3600,
     "15m" => 900,
   }
-  @max_in_window 100
+  @max_in_window 1000
 
   def init(default), do: default
 

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -1,0 +1,27 @@
+defmodule Castle.Redis do
+  @typedoc """
+  A response + metadata tuple.
+  """
+  @type result :: {%{} | [%{}], %{}}
+
+  @doc """
+  Cache the results of a function call.
+  """
+  @callback cached(key :: String.t, ttl :: pos_integer(), work_fn :: (() -> result)) :: result
+  defdelegate cached(key, ttl, work_fn), to: Castle.Redis.ResponseCache,
+    as: :cached
+
+  @doc """
+  Cache a list of intervals for a time range. The worker function will be called
+  with a different from-dtim if there were any cache hits.
+  """
+  @callback interval(key_prefix :: String.t,
+                     from       :: %DateTime{},
+                     to         :: %DateTime{},
+                     interval   :: pos_integer(),
+                     work_fn    :: (new_from :: %DateTime{} -> result)
+                    ) :: result
+  defdelegate interval(key_prefix, from, to, interval, work_fn),
+    to: Castle.Redis.IntervalCache,
+    as: :interval
+end

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -7,21 +7,21 @@ defmodule Castle.Redis do
   @doc """
   Cache the results of a function call.
   """
-  @callback cached(key :: String.t, ttl :: pos_integer(), work_fn :: (() -> result)) :: result
-  defdelegate cached(key, ttl, work_fn), to: Castle.Redis.ResponseCache,
-    as: :cached
+  @callback cached(
+    key     :: String.t,
+    ttl     :: pos_integer(),
+    work_fn :: (() -> result)
+  ) :: result
 
   @doc """
   Cache a list of intervals for a time range. The worker function will be called
   with a different from-dtim if there were any cache hits.
   """
-  @callback interval(key_prefix :: String.t,
-                     from       :: %DateTime{},
-                     to         :: %DateTime{},
-                     interval   :: pos_integer(),
-                     work_fn    :: (new_from :: %DateTime{} -> result)
-                    ) :: result
-  defdelegate interval(key_prefix, from, to, interval, work_fn),
-    to: Castle.Redis.IntervalCache,
-    as: :interval
+  @callback interval(
+    key_prefix :: String.t,
+    from       :: %DateTime{},
+    to         :: %DateTime{},
+    interval   :: pos_integer(),
+    work_fn    :: (new_from :: %DateTime{} -> result)
+  ) :: result
 end

--- a/lib/redis/api.ex
+++ b/lib/redis/api.ex
@@ -1,0 +1,11 @@
+defmodule Castle.Redis.Api do
+  @behaviour Castle.Redis
+
+  defdelegate cached(key, ttl, work_fn),
+    to: Castle.Redis.ResponseCache,
+    as: :cached
+
+  defdelegate interval(key_prefix, from, to, interval, work_fn),
+    to: Castle.Redis.IntervalCache,
+    as: :interval
+end

--- a/lib/redis/interval_cache.ex
+++ b/lib/redis/interval_cache.ex
@@ -1,4 +1,4 @@
-defmodule Castle.Redis.IntervalResponse do
+defmodule Castle.Redis.IntervalCache do
   alias Castle.Redis.Conn, as: Conn
 
   @past_interval_ttl 43200

--- a/lib/redis/response_cache.ex
+++ b/lib/redis/response_cache.ex
@@ -1,4 +1,4 @@
-defmodule Castle.Redis.CachedResponse do
+defmodule Castle.Redis.ResponseCache do
   alias Castle.Redis.Conn, as: Conn
 
   def cached(key, ttl, work_fn) do

--- a/test/controllers/api/download_controller_test.exs
+++ b/test/controllers/api/download_controller_test.exs
@@ -1,13 +1,7 @@
 defmodule Castle.API.DownloadControllerTest do
   use Castle.ConnCase, async: false
-  use Castle.RedisCase
 
   import Mock
-
-  setup do
-    redis_clear("downloads.*")
-    []
-  end
 
   test "requires query params", %{conn: conn} do
     with_mock BigQuery, fake_data() do

--- a/test/controllers/api/impression_controller_test.exs
+++ b/test/controllers/api/impression_controller_test.exs
@@ -1,13 +1,7 @@
 defmodule Castle.API.ImpressionControllerTest do
   use Castle.ConnCase, async: false
-  use Castle.RedisCase
 
   import Mock
-
-  setup do
-    redis_clear("impressions.*")
-    []
-  end
 
   test "requires query params", %{conn: conn} do
     with_mock BigQuery, fake_data() do

--- a/test/plugs/interval_plug_test.exs
+++ b/test/plugs/interval_plug_test.exs
@@ -40,7 +40,7 @@ defmodule Castle.PlugsIntervalTest do
   end
 
   test "validates the intervals per time window", %{conn: conn} do
-    conn = call_interval(conn, "15m", "2017-04-01T00:00:00Z", "2017-04-04T00:00:00Z")
+    conn = call_interval(conn, "15m", "2017-03-01T00:00:00Z", "2017-04-01T00:00:00Z")
     assert conn.status == 400
     assert conn.halted == true
     assert conn.resp_body =~ ~r/time window too large/i

--- a/test/redis/conn_test.exs
+++ b/test/redis/conn_test.exs
@@ -1,38 +1,36 @@
 defmodule Castle.RedisConnTest do
   use Castle.RedisCase, async: true
 
+  @moduletag :redis
+
   import Castle.Redis.Conn
 
   setup do
-    del("some_cache_key")
-    del("other_cache_key")
+    redis_clear("conn_test_*")
     []
   end
 
-  @tag :redis
   test "gets and sets objects" do
-    assert get("some_cache_key") == nil
-    assert set("some_cache_key", %{hello: "world"}) == %{hello: "world"}
-    assert get("some_cache_key") == %{hello: "world"}
+    assert get("conn_test_key1") == nil
+    assert set("conn_test_key1", %{hello: "world"}) == %{hello: "world"}
+    assert get("conn_test_key1") == %{hello: "world"}
   end
 
-  @tag :redis
   test "gets and sets multiple keys at a time" do
-    keys = ~w(some_cache_key other_cache_key foobar)
+    keys = ~w(conn_test_key1 conn_test_key2 foobar)
     assert get(keys) == [nil, nil, nil]
     set(%{
-      some_cache_key: "someval",
-      other_cache_key: %{other: "val"},
+      conn_test_key1: "someval",
+      conn_test_key2: %{other: "val"},
     })
     assert get(keys) == ["someval", %{other: "val"}, nil]
   end
 
-  @tag :redis
   test "deletes objects" do
-    assert set("some_cache_key", 1234) == 1234
-    assert get("some_cache_key") == 1234
-    assert del("some_cache_key") == true
-    assert del("some_cache_key") == false
-    assert get("some_cache_key") == nil
+    assert set("conn_test_key1", 1234) == 1234
+    assert get("conn_test_key1") == 1234
+    assert del("conn_test_key1") == true
+    assert del("conn_test_key1") == false
+    assert get("conn_test_key1") == nil
   end
 end

--- a/test/redis/interval_cache_test.exs
+++ b/test/redis/interval_cache_test.exs
@@ -1,9 +1,11 @@
-defmodule Castle.RedisIntervalResponseTest do
+defmodule Castle.RedisIntervalCacheTest do
   use Castle.RedisCase, async: true
 
-  import Castle.Redis.IntervalResponse
+  @moduletag :redis
 
-  @prefix "interval.response.test"
+  import Castle.Redis.IntervalCache
+
+  @prefix "interval.cache.test"
 
   setup do
     redis_clear("#{@prefix}*")

--- a/test/redis/response_cache_test.exs
+++ b/test/redis/response_cache_test.exs
@@ -1,23 +1,24 @@
-defmodule Castle.RedisCachedResponseTest do
+defmodule Castle.RedisResponseCacheTest do
   use Castle.RedisCase, async: true
 
-  import Castle.Redis.CachedResponse
+  @moduletag :redis
+
+  import Castle.Redis.ResponseCache
 
   setup do
-    Castle.Redis.Conn.del("some_cache_key")
+    redis_clear("response_cache_test*")
     []
   end
 
-  @tag :redis
   test "caches responses but not metadata" do
     data = %{some: "data"}
     meta = %{the: "meta"}
 
-    {d, m} = cached("some_cache_key", 1, fn() -> {data, meta} end)
+    {d, m} = cached("response_cache_test", 1, fn() -> {data, meta} end)
     assert d == %{some: "data"}
     assert m == %{the: "meta"}
 
-    {d, m} = cached("some_cache_key", 1, fn() -> {data, meta} end)
+    {d, m} = cached("response_cache_test", 1, fn() -> {data, meta} end)
     assert d == %{some: "data"}
     assert m == %{cached: true}
   end

--- a/test/support/channel_case.ex
+++ b/test/support/channel_case.ex
@@ -26,7 +26,7 @@ defmodule Castle.ChannelCase do
     end
   end
 
-  setup tags do
+  setup _tags do
 
     :ok
   end

--- a/test/support/fake_redis.ex
+++ b/test/support/fake_redis.ex
@@ -1,0 +1,6 @@
+defmodule Castle.FakeRedis do
+  @behaviour Castle.Redis
+
+  def cached(_key, _ttl, work_fn), do: work_fn.()
+  def interval(_key_prefix, from, _to, _interval, work_fn), do: work_fn.(from)
+end

--- a/web/controllers/api/download_controller.ex
+++ b/web/controllers/api/download_controller.ex
@@ -1,15 +1,16 @@
 defmodule Castle.API.DownloadController do
   use Castle.Web, :controller
 
-  alias Castle.Redis.IntervalResponse, as: Redis
+  @redis Application.get_env(:castle, :redis)
+  @bigquery Application.get_env(:castle, :bigquery)
 
   plug Castle.Plugs.ParseInt, "podcast_id"
 
   def index(conn, %{"podcast_id" => podcast_id}) do
     %{assigns: %{time_from: from, time_to: to, interval: interval}} = conn
 
-    {data, meta} = Redis.interval "downloads.podcast.#{podcast_id}", from, to, interval, fn(new_from) ->
-      BigQuery.podcast_downloads(podcast_id, new_from, to, interval)
+    {data, meta} = @redis.interval "downloads.podcast.#{podcast_id}", from, to, interval, fn(new_from) ->
+      @bigquery.podcast_downloads(podcast_id, new_from, to, interval)
     end
 
     render conn, "podcast.json",
@@ -22,8 +23,8 @@ defmodule Castle.API.DownloadController do
   def index(conn, %{"episode_guid" => episode_guid}) do
     %{assigns: %{time_from: from, time_to: to, interval: interval}} = conn
 
-    {data, meta} = Redis.interval "downloads.episode.#{episode_guid}", from, to, interval, fn(new_from) ->
-      BigQuery.episode_downloads(episode_guid, new_from, to, interval)
+    {data, meta} = @redis.interval "downloads.episode.#{episode_guid}", from, to, interval, fn(new_from) ->
+      @bigquery.episode_downloads(episode_guid, new_from, to, interval)
     end
 
     render conn, "episode.json",

--- a/web/controllers/api/episode_controller.ex
+++ b/web/controllers/api/episode_controller.ex
@@ -1,18 +1,19 @@
 defmodule Castle.API.EpisodeController do
   use Castle.Web, :controller
 
-  alias Castle.Redis.CachedResponse, as: Redis
+  @redis Application.get_env(:castle, :redis)
+  @bigquery Application.get_env(:castle, :bigquery)
 
   @index_ttl 900
   @show_ttl 300
 
   def index(conn, _params) do
-    {episodes, meta} = Redis.cached "episode.index", @index_ttl, fn() -> BigQuery.episodes() end
+    {episodes, meta} = @redis.cached "episode.index", @index_ttl, fn() -> @bigquery.episodes() end
     render conn, "index.json", conn: conn, episodes: episodes, meta: meta
   end
 
   def show(conn, %{"id" => id}) do
-    {episode, meta} = Redis.cached "episode.show.#{id}", @show_ttl, fn() -> BigQuery.episode(id) end
+    {episode, meta} = @redis.cached "episode.show.#{id}", @show_ttl, fn() -> @bigquery.episode(id) end
     render conn, "show.json", conn: conn, episode: episode, meta: meta
   end
 end

--- a/web/controllers/api/impression_controller.ex
+++ b/web/controllers/api/impression_controller.ex
@@ -1,15 +1,16 @@
 defmodule Castle.API.ImpressionController do
   use Castle.Web, :controller
 
-  alias Castle.Redis.IntervalResponse, as: Redis
+  @redis Application.get_env(:castle, :redis)
+  @bigquery Application.get_env(:castle, :bigquery)
 
   plug Castle.Plugs.ParseInt, "podcast_id"
 
   def index(conn, %{"podcast_id" => podcast_id}) do
     %{assigns: %{time_from: from, time_to: to, interval: interval}} = conn
 
-    {data, meta} = Redis.interval "impressions.podcast.#{podcast_id}", from, to, interval, fn(new_from) ->
-      BigQuery.podcast_impressions(podcast_id, new_from, to, interval)
+    {data, meta} = @redis.interval "impressions.podcast.#{podcast_id}", from, to, interval, fn(new_from) ->
+      @bigquery.podcast_impressions(podcast_id, new_from, to, interval)
     end
 
     render conn, "podcast.json",
@@ -22,8 +23,8 @@ defmodule Castle.API.ImpressionController do
   def index(conn, %{"episode_guid" => episode_guid}) do
     %{assigns: %{time_from: from, time_to: to, interval: interval}} = conn
 
-    {data, meta} = Redis.interval "impressions.episode.#{episode_guid}", from, to, interval, fn(new_from) ->
-      BigQuery.episode_impressions(episode_guid, new_from, to, interval)
+    {data, meta} = @redis.interval "impressions.episode.#{episode_guid}", from, to, interval, fn(new_from) ->
+      @bigquery.episode_impressions(episode_guid, new_from, to, interval)
     end
 
     render conn, "episode.json",


### PR DESCRIPTION
See #4.  Define explicit contract/boundary for redis usage.

- [x] Refactor redis (and bigquery while i'm at it) into application configs
- [x] Explicitly test redis module by itself - otherwise mock out completely
- [x] Get rid of key overlaps between redis tests (race conditions there since tests are async)
- [x] Larger max number of windows (1000), so you can get about:
  - 10 days at 15m
  - 40 days at 1h
  - 2.7 years at 1d

Considering doing the same thing for bigquery tests.  But for now, using `Mock` in the controllers is working fine.