### PR TITLE
Async caching strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /_build
 /db
 /deps
+/doc
 /*.ez
 
 # Generated on crash by the VM

--- a/README.md
+++ b/README.md
@@ -71,6 +71,15 @@ iex -S mix phoenix.server
 iex -S mix
 ```
 
+## Rollups
+
+Certain queries can be expensive to run against BigQuery, so we cache these to
+Redis in a background worker.  The interval at which the worker runs in prod is
+configured in `config/prod.exs`.  But in dev/test, these queries will never run
+by default.
+
+To manually get rollups in your development Redis, just run `mix castle.rollup`.
+
 ## Testing
 
 ```

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -35,3 +35,7 @@ config :phoenix, :stacktrace_depth, 20
 # External clients
 config :castle, :redis, Castle.Redis.Api
 config :castle, :bigquery, BigQuery
+
+# Don't run workers - must be manually called with "mix castle.rollup"
+config :castle, :rollup_initial_delay, nil
+config :castle, :rollup_delay, nil

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -22,6 +22,10 @@ config :logger, level: :info
 config :castle, :redis, Castle.Redis.Api
 config :castle, :bigquery, BigQuery
 
+# Worker intervals
+config :castle, :rollup_initial_delay, 60
+config :castle, :rollup_delay, 300
+
 # ## SSL Support
 #
 # To get SSL working, you will need to add the `https` key

--- a/config/test.exs
+++ b/config/test.exs
@@ -12,3 +12,7 @@ config :logger, level: :warn
 # External clients
 config :castle, :redis, Castle.FakeRedis
 config :castle, :bigquery, BigQuery
+
+# Don't run workers during testing
+config :castle, :rollup_initial_delay, nil
+config :castle, :rollup_delay, nil

--- a/lib/castle.ex
+++ b/lib/castle.ex
@@ -8,7 +8,8 @@ defmodule Castle do
 
     # Define workers and child supervisors to be supervised
     children = [
-      supervisor(Castle.Endpoint, [])
+      supervisor(Castle.Endpoint, []),
+      worker(Castle.Rollup.Worker, [])
     ]
 
     # Create the redix children list of workers:

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -68,4 +68,21 @@ defmodule Castle.Redis do
     combiner_fn :: (results :: [%{}] -> [%{}]),
     worker_fns  :: [partition_worker]
   ) :: result
+
+  @doc """
+  Get partition data only from redis - will return empty result on cache miss
+  """
+  @callback partition(
+    key_prefix :: String.t,
+    num_parts  :: pos_integer()
+  ) :: result
+
+  @doc """
+  Get partition data with a custom combiner
+  """
+  @callback partition(
+    key_prefix :: String.t,
+    num_parts  :: pos_integer(),
+    combiner_fn :: (results :: [%{}] -> [%{}])
+  ) :: result
 end

--- a/lib/redis/api.ex
+++ b/lib/redis/api.ex
@@ -13,11 +13,11 @@ defmodule Castle.Redis.Api do
     to: Castle.Redis.IntervalCache,
     as: :interval
 
-  defdelegate partition(key, part_work_fns),
+  defdelegate partition(key_prefix, worker_fns),
     to: Castle.Redis.PartitionCache,
     as: :partition
 
-  defdelegate partition(key, combiner_fn, part_work_fns),
+  defdelegate partition(key_prefix, combiner_fn, worker_fns),
     to: Castle.Redis.PartitionCache,
     as: :partition
 end

--- a/lib/redis/api.ex
+++ b/lib/redis/api.ex
@@ -12,4 +12,12 @@ defmodule Castle.Redis.Api do
   defdelegate interval(key_prefix, from, to, interval, work_fn),
     to: Castle.Redis.IntervalCache,
     as: :interval
+
+  defdelegate partition(key, part_work_fns),
+    to: Castle.Redis.PartitionCache,
+    as: :partition
+
+  defdelegate partition(key, combiner_fn, part_work_fns),
+    to: Castle.Redis.PartitionCache,
+    as: :partition
 end

--- a/lib/redis/api.ex
+++ b/lib/redis/api.ex
@@ -20,4 +20,12 @@ defmodule Castle.Redis.Api do
   defdelegate partition(key_prefix, combiner_fn, worker_fns),
     to: Castle.Redis.PartitionCache,
     as: :partition
+
+  defdelegate partition_get(key_prefix, num_parts),
+    to: Castle.Redis.PartitionCache,
+    as: :partition_get
+
+  defdelegate partition_get(key_prefix, num_parts, combiner_fn),
+    to: Castle.Redis.PartitionCache,
+    as: :partition_get
 end

--- a/lib/redis/conn.ex
+++ b/lib/redis/conn.ex
@@ -22,6 +22,7 @@ defmodule Castle.Redis.Conn do
     command ["SET", key, encode(val)]
     val
   end
+  def set(key, nil, val), do: set(key, val)
   def set(key, ttl, val) do
     command ["SETEX", key, ttl, encode(val)]
     val

--- a/lib/redis/partition_cache.ex
+++ b/lib/redis/partition_cache.ex
@@ -1,8 +1,8 @@
 defmodule Castle.Redis.PartitionCache do
   alias Castle.Redis.Conn, as: Conn
 
-  def partition(key, combiner_fn, part_work_fns) do
-    parts = get_parts(key, 0, nil, part_work_fns)
+  def partition(key, combiner_fn, worker_fns) do
+    parts = get_parts(key, 0, nil, worker_fns)
     data = parts
       |> Enum.map(fn({result, _meta}) -> result end)
       |> Enum.concat()

--- a/lib/redis/partition_cache.ex
+++ b/lib/redis/partition_cache.ex
@@ -1,0 +1,68 @@
+defmodule Castle.Redis.PartitionCache do
+  alias Castle.Redis.Conn, as: Conn
+
+  def partition(key, combiner_fn, part_work_fns) do
+    parts = get_parts(key, 0, nil, part_work_fns)
+    data = parts
+      |> Enum.map(fn({result, _meta}) -> result end)
+      |> Enum.concat()
+      |> combiner_fn.()
+    meta = parts
+      |> Enum.map(fn({_result, meta}) -> meta end)
+      |> combine_meta()
+    {data, meta}
+  end
+  def partition(key, fns), do: partition(key, fn(parts) -> parts end, fns)
+
+  defp get_parts(key, index, date, [_part | rest] = parts) do
+    case Conn.get("#{key}.#{index}") do
+      nil ->
+        get_parts_uncached(key, index, date, parts)
+      [next_date, val] ->
+        [{val, %{cached: true}}] ++ get_parts(key, index + 1, parse(next_date), rest)
+    end
+  end
+  defp get_parts(_key, _index, _date, []), do: []
+
+  defp get_parts_uncached(key, index, date, [work_fn | rest]) when is_function(work_fn) do
+    get_parts_uncached(key, index, date, [{nil, work_fn}] ++ rest)
+  end
+  defp get_parts_uncached(key, index, date, [{ttl, work_fn} | rest]) do
+    {next_date, val, meta} = case call_fn(work_fn, date) do
+      {v, m} -> {nil, v, m}
+      {k, v, m} -> {k, v, m}
+    end
+    Conn.set("#{key}.#{index}", ttl, [format(next_date), val])
+    [{val, meta}] ++ get_parts_uncached(key, index + 1, next_date, rest)
+  end
+  defp get_parts_uncached(_key, _index, _date, []), do: []
+
+  defp call_fn(work_fn, nil), do: work_fn.()
+  defp call_fn(work_fn, date), do: work_fn.(date)
+
+  defp format(nil), do: nil
+  defp format(dtim) do
+    {:ok, formatted} = Timex.format(dtim, "{ISO:Extended:Z}")
+    formatted
+  end
+
+  defp parse(nil), do: nil
+  defp parse(dtim_str) do
+    {:ok, dtim} = Timex.parse(dtim_str, "{ISO:Extended:Z}")
+    dtim
+  end
+
+  defp combine_meta(metas) do
+    metas
+    |> Enum.map(&Map.to_list/1)
+    |> Enum.concat()
+    |> Enum.reduce(%{}, fn({key, val}, acc) ->
+      Map.merge acc, Map.put(%{}, key, val), fn k, v1, v2 ->
+        case k do
+          :cached -> v1 && v2
+          _ -> v1 + v2
+        end
+      end
+    end)
+  end
+end

--- a/lib/redis/partition_cache.ex
+++ b/lib/redis/partition_cache.ex
@@ -84,7 +84,11 @@ defmodule Castle.Redis.PartitionCache do
       Map.merge acc, Map.put(%{}, key, val), fn k, v1, v2 ->
         case k do
           :cached -> v1 && v2
-          _ -> v1 + v2
+          _ when is_number(v1) and is_number(v2) -> v1 + v2
+          _ when is_list(v1) and is_list(v2) -> v1 ++ v2
+          _ when is_list(v1) and not is_list(v2) -> v1 ++ [v2]
+          _ when is_list(v2) and not is_list(v1) -> [v1] ++ v2
+          _ -> [v1, v2]
         end
       end
     end)

--- a/lib/rollup.ex
+++ b/lib/rollup.ex
@@ -1,0 +1,8 @@
+defmodule Castle.Rollup do
+
+  alias Castle.Rollup.Data, as: Data
+
+  defdelegate total_podcast_downloads(id), to: Data.Totals, as: :podcast_downloads
+  defdelegate total_episode_downloads(guid), to: Data.Totals, as: :episode_downloads
+
+end

--- a/lib/rollup/data/totals_data.ex
+++ b/lib/rollup/data/totals_data.ex
@@ -1,6 +1,40 @@
 defmodule Castle.Rollup.Data.Totals do
   import Castle.Rollup.Jobs.Totals
 
+  # TODO: this is real ugly. Just trying to combine/sort the episode maps
+  def podcasts() do
+    {result, _meta} = get()
+    result
+    |> Enum.map(&(Map.put(&1, :feeder_episodes, [&1.feeder_episode])))
+    |> Enum.map(&(Map.delete(&1, :feeder_episode)))
+    |> Enum.group_by(&(&1.feeder_podcast))
+    |> Enum.map(fn({_podcast_id, episodes}) ->
+      Enum.reduce(episodes, %{}, fn(episode, acc) ->
+        Map.merge(acc, episode, fn(k, v1, v2) ->
+          case k do
+            :count -> v1 + v2
+            :feeder_episodes -> Enum.sort(v1 ++ v2)
+            _ -> v2
+          end
+        end)
+      end)
+    end)
+    |> Enum.sort(&(&1.feeder_podcast < &2.feeder_podcast))
+  end
+
+  def podcast(id) do
+    podcasts() |> Enum.find(&(&1.feeder_podcast == id))
+  end
+
+  def episodes() do
+    {result, _meta} = get()
+    result |> Enum.sort(&(&1.feeder_episode < &2.feeder_episode))
+  end
+
+  def episode(guid) do
+    episodes() |> Enum.find(&(&1.feeder_episode == guid))
+  end
+
   def podcast_downloads(podcast_id) do
     find_count &(&1.feeder_podcast == podcast_id)
   end

--- a/lib/rollup/data/totals_data.ex
+++ b/lib/rollup/data/totals_data.ex
@@ -1,0 +1,19 @@
+defmodule Castle.Rollup.Data.Totals do
+  import Castle.Rollup.Jobs.Totals
+
+  def podcast_downloads(podcast_id) do
+    find_count &(&1.feeder_podcast == podcast_id)
+  end
+
+  def episode_downloads(episode_guid) do
+    find_count &(&1.feeder_episode == episode_guid)
+  end
+
+  defp find_count(finder_fn) do
+    {result, _meta} = get()
+    result
+    |> Enum.filter(finder_fn)
+    |> Enum.map(&(&1.count))
+    |> Enum.sum()
+  end
+end

--- a/lib/rollup/jobs/totals_job.ex
+++ b/lib/rollup/jobs/totals_job.ex
@@ -1,4 +1,5 @@
 defmodule Castle.Rollup.Jobs.Totals do
+  # TODO: import "public" redis api from the application
   import Castle.Redis.PartitionCache
 
   # cache for 15d/24h/5m
@@ -47,7 +48,8 @@ defmodule Castle.Rollup.Jobs.Totals do
     """
       SELECT feeder_podcast, feeder_episode, COUNT(*) AS count
       FROM #{Env.get(:bq_downloads_table)}
-      WHERE is_duplicate = false AND #{where_sql}
+      WHERE is_duplicate = false AND feeder_podcast IS NOT NULL
+      AND feeder_episode IS NOT NULL AND #{where_sql}
       GROUP BY feeder_podcast, feeder_episode
     """
   end

--- a/lib/rollup/jobs/totals_job.ex
+++ b/lib/rollup/jobs/totals_job.ex
@@ -2,7 +2,9 @@ defmodule Castle.Rollup.Jobs.Totals do
   # TODO: import "public" redis api from the application
   import Castle.Redis.PartitionCache
 
-  # cache for 15d/24h/5m
+  # old - all non-today partitions from the beginning of time - 15 day cache
+  # mid - intermediate query to pick up the slack - 1 day cache
+  # new - always the current-date-partition - 5 minute cache
   def run() do
     partition "rollup.totals", &Castle.Rollup.Jobs.Totals.combine/1, [
       {1296000, &Castle.Rollup.Jobs.Totals.old_part/0},

--- a/lib/rollup/jobs/totals_job.ex
+++ b/lib/rollup/jobs/totals_job.ex
@@ -6,7 +6,7 @@ defmodule Castle.Rollup.Jobs.Totals do
     partition "rollups.total", &Castle.Rollup.Jobs.Totals.combine/1, [
       {1296000, &Castle.Rollup.Jobs.Totals.old_part/0},
       {86400, &Castle.Rollup.Jobs.Totals.mid_part/1},
-      {30, &Castle.Rollup.Jobs.Totals.new_part/1}]
+      {300, &Castle.Rollup.Jobs.Totals.new_part/1}]
   end
 
   def combine(parts) do

--- a/lib/rollup/jobs/totals_job.ex
+++ b/lib/rollup/jobs/totals_job.ex
@@ -3,10 +3,14 @@ defmodule Castle.Rollup.Jobs.Totals do
 
   # cache for 15d/24h/5m
   def run() do
-    partition "rollups.total", &Castle.Rollup.Jobs.Totals.combine/1, [
+    partition "rollup.totals", &Castle.Rollup.Jobs.Totals.combine/1, [
       {1296000, &Castle.Rollup.Jobs.Totals.old_part/0},
       {86400, &Castle.Rollup.Jobs.Totals.mid_part/1},
       {300, &Castle.Rollup.Jobs.Totals.new_part/1}]
+  end
+
+  def get() do
+    partition_get "rollup.totals", 3, &Castle.Rollup.Jobs.Totals.combine/1
   end
 
   def combine(parts) do

--- a/lib/rollup/jobs/totals_job.ex
+++ b/lib/rollup/jobs/totals_job.ex
@@ -1,0 +1,59 @@
+defmodule Castle.Rollup.Jobs.Totals do
+  import Castle.Redis.PartitionCache
+
+  # cache for 15d/24h/5m
+  def run() do
+    partition "rollups.total", &Castle.Rollup.Jobs.Totals.combine/1, [
+      {1296000, &Castle.Rollup.Jobs.Totals.old_part/0},
+      {86400, &Castle.Rollup.Jobs.Totals.mid_part/1},
+      {30, &Castle.Rollup.Jobs.Totals.new_part/1}]
+  end
+
+  def combine(parts) do
+    parts
+    |> Enum.sort(&(&1.feeder_episode >= &2.feeder_episode))
+    |> Enum.reduce([], &combine_parts/2)
+  end
+
+  def old_part() do
+    end_dtim = Timex.beginning_of_day(Timex.now())
+    sql = sql("_PARTITIONTIME < @upper")
+    {result, meta} = BigQuery.Base.Query.query %{upper: end_dtim}, sql
+    {end_dtim, result, Map.put(meta, :job, [{nil, end_dtim}])}
+  end
+
+  def mid_part(start_dtim) do
+    end_dtim = Timex.beginning_of_day(Timex.now())
+    if start_dtim == end_dtim do
+      {end_dtim, [], %{cached: true}}
+    else
+      sql = sql("_PARTITIONTIME >= @lower AND _PARTITIONTIME < @upper")
+      {result, meta} = BigQuery.Base.Query.query %{lower: start_dtim, upper: end_dtim}, sql
+      {end_dtim, result, Map.put(meta, :job, [{start_dtim, end_dtim}])}
+    end
+  end
+
+  def new_part(start_dtim) do
+    sql = sql("_PARTITIONTIME >= @lower")
+    {result, meta} = BigQuery.Base.Query.query %{lower: start_dtim}, sql
+    {nil, result, Map.put(meta, :job, [{start_dtim, nil}])}
+  end
+
+  defp sql(where_sql) do
+    """
+      SELECT feeder_podcast, feeder_episode, COUNT(*) AS count
+      FROM #{Env.get(:bq_downloads_table)}
+      WHERE is_duplicate = false AND #{where_sql}
+      GROUP BY feeder_podcast, feeder_episode
+    """
+  end
+
+  defp combine_parts(%{count: n, feeder_episode: guid} = part, [last | rest]) do
+    if last.feeder_episode == guid do
+      [Map.put(last, :count, last.count + n)] ++ rest
+    else
+      [part] ++ [last] ++ rest
+    end
+  end
+  defp combine_parts(part, _), do: [part]
+end

--- a/lib/rollup/task.ex
+++ b/lib/rollup/task.ex
@@ -1,0 +1,10 @@
+defmodule Mix.Tasks.Castle.Rollup do
+  use Mix.Task
+
+  @shortdoc "Manually run the BigQuery data rollups"
+
+  def run(_) do
+    {:ok, _started} = Application.ensure_all_started(:castle)
+    Castle.Rollup.Worker.run_jobs(%{log: true})
+  end
+end

--- a/lib/rollup/worker.ex
+++ b/lib/rollup/worker.ex
@@ -3,10 +3,12 @@ require Logger
 defmodule Castle.Rollup.Worker do
   use GenServer
 
+  @jobs [
+    {Castle.Rollup.Jobs.Totals, :run, []},
+  ]
+
   def start_link do
-    GenServer.start_link(__MODULE__, %{jobs: [
-      {Castle.Rollup.Jobs.Totals, :run, []},
-    ]})
+    GenServer.start_link(__MODULE__, %{})
   end
 
   def init(state) do
@@ -14,35 +16,51 @@ defmodule Castle.Rollup.Worker do
     {:ok, state}
   end
 
+  def handle_info(:work, state) do
+    run_jobs(state)
+    Application.get_env(:castle, :rollup_delay) |> reschedule()
+    {:noreply, state}
+  end
+
+  def run_jobs(state) do
+    Enum.each @jobs, fn(job) -> run_job(job, state) end
+  end
+
   defp reschedule(nil), do: nil
   defp reschedule(wait_seconds) do
     Process.send_after self(), :work, wait_seconds * 1000
   end
 
-  def handle_info(:work, state) do
-    Enum.each(state.jobs, &run_job/1)
-    Application.get_env(:castle, :rollup_delay) |> reschedule()
-    {:noreply, state}
-  end
-
-  defp run_job({module, name, args}) do
+  defp run_job({module, name, args}, %{log: true}) do
+    IO.puts "Running: #{module}"
     {_result, meta} = apply(module, name, args)
-    log_meta(module, meta)
-  end
-
-  defp log_meta(module, %{job: jobs, total: total, megabytes: megabytes} = meta) do
-    dates = jobs |> Enum.map(&format_dates/1) |> Enum.join(", ")
-    if meta.cached do
-      Logger.debug "ROLLUP #{module} #{dates} - #{total} total, #{megabytes} mb CACHED"
+    if Map.has_key?(meta, :job) do
+      IO.puts "  #{format_meta(meta)}"
     else
-      Logger.info "ROLLUP #{module} #{dates} - #{total} total, #{megabytes} mb"
+      IO.puts "  no partitions expired"
     end
   end
-  defp log_meta(_module, _meta), do: nil
+
+  defp run_job({module, name, args}, _state) do
+    {_result, meta} = apply(module, name, args)
+    if Map.has_key?(meta, :job) do
+      Logger.debug "ROLLUP #{module} #{format_meta(meta)}"
+    end
+  end
+
+  defp format_meta(%{cached: true} = meta) do
+    base = Map.delete(meta, :cached) |> format_meta()
+    "#{base} CACHED"
+  end
+  defp format_meta(%{job: jobs, total: total, megabytes: megabytes}) do
+    "#{format_dates(jobs)} / #{total} total, #{megabytes} mb"
+  end
 
   defp format_dates({nil, dtim}), do: "< #{format_date(dtim)}"
   defp format_dates({dtim, nil}), do: ">= #{format_date(dtim)}"
   defp format_dates({dtim1, dtim2}), do: "#{format_date(dtim1)} to #{format_date(dtim2)}"
+  defp format_dates(nil), do: ""
+  defp format_dates(jobs), do: Enum.map(jobs, &format_dates/1) |> Enum.join(", ")
 
   defp format_date(dtim) do
     {:ok, str} = Timex.format(dtim, "%Y-%m-%d", :strftime)

--- a/lib/rollup/worker.ex
+++ b/lib/rollup/worker.ex
@@ -21,6 +21,7 @@ defmodule Castle.Rollup.Worker do
     Application.get_env(:castle, :rollup_delay) |> reschedule()
     {:noreply, state}
   end
+  def handle_info(_, state), do: {:noreply, state}
 
   def run_jobs(state) do
     Enum.each @jobs, fn(job) -> run_job(job, state) end

--- a/lib/rollup/worker.ex
+++ b/lib/rollup/worker.ex
@@ -1,0 +1,51 @@
+require Logger
+
+defmodule Castle.Rollup.Worker do
+  use GenServer
+
+  def start_link do
+    GenServer.start_link(__MODULE__, %{jobs: [
+      {Castle.Rollup.Jobs.Totals, :run, []},
+    ]})
+  end
+
+  def init(state) do
+    Application.get_env(:castle, :rollup_initial_delay) |> reschedule()
+    {:ok, state}
+  end
+
+  defp reschedule(nil), do: nil
+  defp reschedule(wait_seconds) do
+    Process.send_after self(), :work, wait_seconds * 1000
+  end
+
+  def handle_info(:work, state) do
+    Enum.each(state.jobs, &run_job/1)
+    Application.get_env(:castle, :rollup_delay) |> reschedule()
+    {:noreply, state}
+  end
+
+  defp run_job({module, name, args}) do
+    {_result, meta} = apply(module, name, args)
+    log_meta(module, meta)
+  end
+
+  defp log_meta(module, %{job: jobs, total: total, megabytes: megabytes} = meta) do
+    dates = jobs |> Enum.map(&format_dates/1) |> Enum.join(", ")
+    if meta.cached do
+      Logger.debug "ROLLUP #{module} #{dates} - #{total} total, #{megabytes} mb CACHED"
+    else
+      Logger.info "ROLLUP #{module} #{dates} - #{total} total, #{megabytes} mb"
+    end
+  end
+  defp log_meta(_module, _meta), do: nil
+
+  defp format_dates({nil, dtim}), do: "< #{format_date(dtim)}"
+  defp format_dates({dtim, nil}), do: ">= #{format_date(dtim)}"
+  defp format_dates({dtim1, dtim2}), do: "#{format_date(dtim1)} to #{format_date(dtim2)}"
+
+  defp format_date(dtim) do
+    {:ok, str} = Timex.format(dtim, "%Y-%m-%d", :strftime)
+    str
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,8 @@ defmodule Castle.Mixfile do
      compilers: [:phoenix, :gettext] ++ Mix.compilers,
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps()]
+     deps: deps(),
+     docs: docs()]
   end
 
   # Configuration for the OTP application.
@@ -39,6 +40,7 @@ defmodule Castle.Mixfile do
      {:phoenix_pubsub, "~> 1.0"},
      {:phoenix_html, "~> 2.6"},
      {:phoenix_live_reload, "~> 1.0", only: :dev},
+     {:ex_doc, "~> 0.14", only: :dev, runtime: false},
      {:gettext, "~> 0.11"},
      {:cowboy, "~> 1.0"},
      {:jose, "~> 1.8"},
@@ -50,5 +52,10 @@ defmodule Castle.Mixfile do
      {:prx_auth, "~> 0.0.1"},
      {:dotenv, "~> 2.1", only: [:dev, :test]},
      {:mock, "~> 0.2.0", only: :test}]
+  end
+
+  defp docs do
+    [main: "readme",
+     extras: ["README.md"]]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -6,6 +6,8 @@
   "cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, repo: "hexpm", optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, repo: "hexpm", optional: false]}], "hexpm"},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], [], "hexpm"},
   "dotenv": {:hex, :dotenv, "2.1.0", "2a66462dbc3038c43147a67a6c4d6eab365223c4bd5ba6f6205db9da0e3e3068", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.3", "206eb2e2ac1a794aa5256f3982de7a76bf4579ff91cb28d0e17ea2c9491e46a4", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.16.3", "cd2a4cfe5d26e37502d3ec776702c72efa1adfa24ed9ce723bb565f4c30bd31a", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "fs": {:hex, :fs, "0.9.2", "ed17036c26c3f70ac49781ed9220a50c36775c6ca2cf8182d123b6566e49ec59", [:rebar], [], "hexpm"},
   "gettext": {:hex, :gettext, "0.13.1", "5e0daf4e7636d771c4c71ad5f3f53ba09a9ae5c250e1ab9c42ba9edccc476263", [:mix], [], "hexpm"},
   "hackney": {:hex, :hackney, "1.7.1", "e238c52c5df3c3b16ce613d3a51c7220a784d734879b1e231c9babd433ac1cb4", [:rebar3], [{:certifi, "1.0.0", [hex: :certifi, repo: "hexpm", optional: false]}, {:idna, "4.0.0", [hex: :idna, repo: "hexpm", optional: false]}, {:metrics, "1.0.1", [hex: :metrics, repo: "hexpm", optional: false]}, {:mimerl, "1.0.2", [hex: :mimerl, repo: "hexpm", optional: false]}, {:ssl_verify_fun, "1.1.1", [hex: :ssl_verify_fun, repo: "hexpm", optional: false]}], "hexpm"},

--- a/test/controllers/api/podcast_controller_test.exs
+++ b/test/controllers/api/podcast_controller_test.exs
@@ -1,11 +1,13 @@
 defmodule Castle.API.PodcastControllerTest do
   use Castle.ConnCase, async: false
 
+  alias Castle.Rollup.Data.Totals, as: Totals
+
   import Mock
 
   describe "index/2" do
     test "responds with a list of podcasts", %{conn: conn} do
-      with_mock BigQuery, fake_datas() do
+      with_mock Totals, fake_datas() do
         resp = conn |> get(api_podcast_path(conn, :index)) |> json_response(200)
         assert resp["count"] == 2
         assert resp["total"] == 2
@@ -16,25 +18,34 @@ defmodule Castle.API.PodcastControllerTest do
 
   describe "show/2" do
     test "responds with a single podcast", %{conn: conn} do
-      with_mock BigQuery, fake_data() do
+      with_mock Totals, fake_data() do
         resp = conn |> get(api_podcast_path(conn, :show, 999)) |> json_response(200)
         assert resp["id"] == 999
         assert "_links" in Map.keys(resp)
       end
     end
+
+    test "renders 404s", %{conn: conn} do
+      with_mock Totals, fake_empty() do
+        resp = conn |> get(api_podcast_path(conn, :show, 999))
+        assert resp.status == 404
+      end
+    end
   end
 
   defp fake_data do
-    [podcast: fn(id) -> {podcast_json(id), %{meta: "data"}} end]
+    [podcast: fn(id) -> podcast_json(id) end]
+  end
+
+  defp fake_empty do
+    [podcast: fn(_id) -> nil end]
   end
 
   defp fake_datas do
-    [podcasts: fn() -> {[podcast_json("foo"), podcast_json("bar")], %{meta: "data"}} end]
+    [podcasts: fn() -> [podcast_json("foo"), podcast_json("bar")] end]
   end
 
   defp podcast_json(id) do
-    %{feeder_podcast: id,
-      downloads_past1: 10, downloads_past12: 20, downloads_past24: 30, downloads_past48: 40,
-      impressions_past1: 1, impressions_past12: 2, impressions_past24: 3, impressions_past48: 4}
+    %{feeder_podcast: id, feeder_episodes: [], count: 999}
   end
 end

--- a/test/redis/partition_cache_test.exs
+++ b/test/redis/partition_cache_test.exs
@@ -1,0 +1,107 @@
+defmodule Castle.RedisPartitionCacheTest do
+  use Castle.RedisCase, async: true
+
+  @moduletag :redis
+
+  import Castle.Redis.PartitionCache
+
+  @prefix "partition.cache.test"
+
+  setup do
+    redis_clear("#{@prefix}*")
+    {:ok, dtim1, _} = DateTime.from_iso8601("2017-03-22T02:45:00Z")
+    {:ok, dtim2, _} = DateTime.from_iso8601("2017-03-29T02:46:00Z")
+    {:ok, dtim3, _} = DateTime.from_iso8601("2017-03-30T02:47:00Z")
+    [date1: dtim1, date2: dtim2, date3: dtim3]
+  end
+
+  test "combines a result list", %{date1: date1, date2: date2, date3: date3} do
+    {result, _meta} = partition @prefix, [
+      fn() -> {date1, ["a", "b"], %{}} end,
+      fn(_date) -> {["b", "c", "d"], %{}} end,
+      fn() -> {date2, [], %{}} end,
+      fn(_date) -> {date3, ["b"], %{}} end]
+    assert length(result) == 6
+    assert result == ["a", "b", "b", "c", "d", "b"]
+  end
+
+  test "custom combines result list", %{date1: date1, date2: date2, date3: date3} do
+    {result, _meta} = partition @prefix, fn(parts) -> Enum.uniq(parts) end, [
+      fn() -> {date1, ["a", "b"], %{}} end,
+      fn(_date) -> {["b", "c", "d"], %{}} end,
+      fn() -> {date2, [], %{}} end,
+      fn(_date) -> {date3, ["b"], %{}} end]
+    assert length(result) == 4
+    assert result == ["a", "b", "c", "d"]
+  end
+
+  test "combines the metadata", %{date1: date1, date2: date2} do
+    {_result, meta} = partition @prefix, [
+      fn() -> {date1, [], %{cached: true}} end,
+      fn(_date) -> {date2, [], %{cached: true, megabytes: 1, total: 2}} end,
+      fn(_date) -> {nil, [], %{bytes: 3, cached: false, megabytes: 999, total: 1}} end]
+    assert meta.cached == false
+    assert meta.bytes == 3
+    assert meta.megabytes == 1000
+    assert meta.total == 3
+  end
+
+  test "caches function results in redis", %{date1: date1, date2: date2} do
+    {data1, _} = partition @prefix, [
+      fn() -> {date1, ["foo1"], %{}} end,
+      fn(_date) -> {date2, ["foo2"], %{}} end,
+      fn(_date) -> {["foo3"], %{}} end]
+    assert redis_count("#{@prefix}.*") == 3
+    assert data1 == ["foo1", "foo2", "foo3"]
+
+    {data2, _} = partition @prefix, [
+      fn() -> {date1, ["bar1"], %{}} end,
+      fn(_date) -> {date2, ["bar2"], %{}} end,
+      fn(_date) -> {["bar3"], %{}} end]
+    assert data2 == ["foo1", "foo2", "foo3"]
+  end
+
+  test "passes dates between partitions", %{date1: date1, date2: date2, date3: date3} do
+    {data, _} = partition @prefix, [
+      fn() -> {date1, ["foo1"], %{}} end,
+      fn(date) ->
+        assert date == date1
+        {date2, ["foo2"], %{}}
+      end,
+      fn(date) ->
+        assert date == date2
+        {nil, ["foo3"], %{}}
+      end]
+    assert data == ["foo1", "foo2", "foo3"]
+
+    # expire part 2, which should re-run 2 and 3
+    [_, key, _] = redis_keys("#{@prefix}.*") |> Enum.sort()
+    redis_clear(key)
+
+    {data, _} = partition @prefix, [
+      fn() -> throw("should not have gotten here") end,
+      fn(date) ->
+        assert date == date1
+        {date3, ["bar2"], %{}}
+      end,
+      fn(date) ->
+        assert date == date3
+        {nil, ["bar3"], %{}}
+      end]
+    assert data == ["foo1", "bar2", "bar3"]
+  end
+
+  test "expires partitions", %{date1: date1, date2: date2, date3: date3} do
+    partition @prefix, [
+      {20, fn() -> {date1, ["foo1"], %{}} end},
+      fn(_) -> {date2, ["foo2"], %{}} end,
+      {nil, fn(_) -> {date3, ["foo3"], %{}} end},
+      {1, fn(_) -> {nil, ["foo4"], %{}} end}]
+    [k1, k2, k3, k4] = redis_keys("#{@prefix}.*") |> Enum.sort()
+
+    assert Castle.Redis.Conn.command(["ttl", k1]) == 20
+    assert Castle.Redis.Conn.command(["ttl", k2]) == -1
+    assert Castle.Redis.Conn.command(["ttl", k3]) == -1
+    assert Castle.Redis.Conn.command(["ttl", k4]) == 1
+  end
+end

--- a/test/redis/partition_cache_test.exs
+++ b/test/redis/partition_cache_test.exs
@@ -37,13 +37,14 @@ defmodule Castle.RedisPartitionCacheTest do
 
   test "combines the metadata", %{date1: date1, date2: date2} do
     {_result, meta} = partition @prefix, [
-      fn() -> {date1, [], %{cached: true}} end,
+      fn() -> {date1, [], %{cached: true, foo: "bar1"}} end,
       fn(_date) -> {date2, [], %{cached: true, megabytes: 1, total: 2}} end,
-      fn(_date) -> {nil, [], %{bytes: 3, cached: false, megabytes: 999, total: 1}} end]
+      fn(_date) -> {nil, [], %{bytes: 3, cached: false, megabytes: 999, total: 1, foo: "bar3"}} end]
     assert meta.cached == false
     assert meta.bytes == 3
     assert meta.megabytes == 1000
     assert meta.total == 3
+    assert meta.foo == ["bar1", "bar3"]
   end
 
   test "caches function results in redis", %{date1: date1, date2: date2} do

--- a/test/redis/partition_cache_test.exs
+++ b/test/redis/partition_cache_test.exs
@@ -116,4 +116,23 @@ defmodule Castle.RedisPartitionCacheTest do
     assert data == ["foo1", "foo2", "bar3", "bar4"]
     assert redis_count("#{@prefix}.*") == 4
   end
+
+  test "gets data without the worker functions", %{date1: date1, date2: date2} do
+    {data, meta} = partition_get(@prefix, 4)
+    assert data == []
+    assert meta == %{cached: true}
+
+    partition @prefix, [
+      fn() -> {date1, ["foo1"], %{}} end,
+      fn(_) -> {date2, ["foo2"], %{}} end,
+      fn(_) -> {nil, ["foo3"], %{}} end]
+
+    {data, meta} = partition_get(@prefix, 3)
+    assert data == ["foo1", "foo2", "foo3"]
+    assert meta == %{cached: true}
+
+    {data, meta} = partition_get(@prefix, 2)
+    assert data == ["foo1", "foo2"]
+    assert meta == %{cached: true}
+  end
 end

--- a/test/rollup/data/totals_data_test.exs
+++ b/test/rollup/data/totals_data_test.exs
@@ -12,6 +12,35 @@ defmodule Castle.Rollup.Data.TotalsTest do
   #   assert episode_downloads("d7a8935e-b735-4ecc-afff-0a804ac40fd9") > 100
   # end
 
+  test "lists podcasts" do
+    with_mock Castle.Rollup.Jobs.Totals, fake_getter() do
+      list = podcasts()
+      assert length(list) == 2
+      assert Enum.at(list, 0).feeder_podcast == 5
+      assert Enum.at(list, 0).count == 14
+      assert Enum.at(list, 0).feeder_episodes == ["guid1", "guid2"]
+      assert Enum.at(list, 1).feeder_podcast == 6
+      assert Enum.at(list, 1).count == 3
+      assert Enum.at(list, 1).feeder_episodes == ["guid3"]
+    end
+  end
+
+  test "lists episodes" do
+    with_mock Castle.Rollup.Jobs.Totals, fake_getter() do
+      list = episodes()
+      assert length(list) == 3
+      assert Enum.at(list, 0).feeder_episode == "guid1"
+      assert Enum.at(list, 0).feeder_podcast == 5
+      assert Enum.at(list, 0).count == 9
+      assert Enum.at(list, 1).feeder_episode == "guid2"
+      assert Enum.at(list, 1).feeder_podcast == 5
+      assert Enum.at(list, 1).count == 5
+      assert Enum.at(list, 2).feeder_episode == "guid3"
+      assert Enum.at(list, 2).feeder_podcast == 6
+      assert Enum.at(list, 2).count == 3
+    end
+  end
+
   test "gets podcast download counts" do
     with_mock Castle.Rollup.Jobs.Totals, fake_getter() do
       assert podcast_downloads(5) == 14
@@ -31,8 +60,8 @@ defmodule Castle.Rollup.Data.TotalsTest do
 
   defp fake_getter do
     results = [
-      %{count: 9, feeder_episode: "guid1", feeder_podcast: 5},
       %{count: 5, feeder_episode: "guid2", feeder_podcast: 5},
+      %{count: 9, feeder_episode: "guid1", feeder_podcast: 5},
       %{count: 3, feeder_episode: "guid3", feeder_podcast: 6},
     ]
     [get: fn() -> {results, %{cached: true}} end]

--- a/test/rollup/data/totals_data_test.exs
+++ b/test/rollup/data/totals_data_test.exs
@@ -1,0 +1,41 @@
+import Mock
+
+defmodule Castle.Rollup.Data.TotalsTest do
+  use Castle.ConnCase, async: false
+
+  import Castle.Rollup.Data.Totals
+
+  # TODO: this doesn't work unless you've "mix castle.rollup"d first
+  # @tag :external
+  # test "actually works" do
+  #   assert podcast_downloads(25) > 10000
+  #   assert episode_downloads("d7a8935e-b735-4ecc-afff-0a804ac40fd9") > 100
+  # end
+
+  test "gets podcast download counts" do
+    with_mock Castle.Rollup.Jobs.Totals, fake_getter() do
+      assert podcast_downloads(5) == 14
+      assert podcast_downloads(6) == 3
+      assert podcast_downloads(7) == 0
+    end
+  end
+
+  test "gets episode download counts" do
+    with_mock Castle.Rollup.Jobs.Totals, fake_getter() do
+      assert episode_downloads("guid1") == 9
+      assert episode_downloads("guid2") == 5
+      assert episode_downloads("guid3") == 3
+      assert episode_downloads("guid4") == 0
+    end
+  end
+
+  defp fake_getter do
+    results = [
+      %{count: 9, feeder_episode: "guid1", feeder_podcast: 5},
+      %{count: 5, feeder_episode: "guid2", feeder_podcast: 5},
+      %{count: 3, feeder_episode: "guid3", feeder_podcast: 6},
+    ]
+    [get: fn() -> {results, %{cached: true}} end]
+  end
+
+end

--- a/test/rollup/jobs/totals_job_test.exs
+++ b/test/rollup/jobs/totals_job_test.exs
@@ -1,0 +1,36 @@
+defmodule Castle.Rollup.Jobs.TotalsTest do
+  use Castle.BigQueryCase, async: true
+
+  import Castle.Rollup.Jobs.Totals
+
+  test "combines results" do
+    results = combine([
+      %{count: 1, feeder_podcast: 123, feeder_episode: "123-1"},
+      %{count: 3, feeder_podcast: 123, feeder_episode: "123-2"},
+      %{count: 7, feeder_podcast: 456, feeder_episode: "456-1"},
+      %{count: 9, feeder_podcast: 789, feeder_episode: "789-1"},
+      %{count: 2, feeder_podcast: 123, feeder_episode: "123-2"},
+      %{count: 4, feeder_podcast: 789, feeder_episode: "789-2"},
+      %{count: 6, feeder_podcast: 123, feeder_episode: "123-1"},
+    ])
+
+    assert podcast(results, "123-1") == 123
+    assert count(results, "123-1") == 7
+    assert podcast(results, "123-2") == 123
+    assert count(results, "123-2") == 5
+    assert podcast(results, "456-1") == 456
+    assert count(results, "456-1") == 7
+    assert podcast(results, "789-1") == 789
+    assert count(results, "789-1") == 9
+    assert podcast(results, "789-2") == 789
+    assert count(results, "789-2") == 4
+  end
+
+  defp podcast(results, guid) do
+    Enum.find(results, &(&1.feeder_episode == guid)).feeder_podcast
+  end
+
+  defp count(results, guid) do
+    Enum.find(results, &(&1.feeder_episode == guid)).count
+  end
+end

--- a/test/support/fake_redis.ex
+++ b/test/support/fake_redis.ex
@@ -4,4 +4,10 @@ defmodule Castle.FakeRedis do
   def cached(_key, _ttl, work_fn), do: work_fn.()
   def interval(_key_prefix, from, _to, _interval, work_fn), do: work_fn.(from)
   def interval(_key_prefix, intv, work_fn), do: work_fn.(intv)
+
+  # TODO: these aren't as easy
+  def partition(_key_prefix, _worker_fns), do: {[], %{fake: true}}
+  def partition(_key_prefix, _combiner_fn, _worker_fns), do: {[], %{fake: true}}
+  def partition_get(_key_prefix, _num_parts), do: {[], %{fake: true}}
+  def partition_get(_key_prefix, _num_parts, _combiner_fn), do: {[], %{fake: true}}
 end

--- a/test/views/api/episode_view_test.exs
+++ b/test/views/api/episode_view_test.exs
@@ -11,20 +11,14 @@ defmodule Castle.API.EpisodeViewTest do
     assert doc.total == 2
     assert length(embedded) == 2
     assert hd(embedded).guid == "foo"
-    assert hd(embedded).downloads.past1 == 10
+    assert hd(embedded).downloads.total == 999
   end
 
   test "show.json", %{conn: conn} do
     doc = render("show.json", %{conn: conn, episode: test_episode("foo"), meta: %{}})
     assert doc.guid == "foo"
-    assert doc.downloads.past1 == 10
-    assert doc.downloads.past12 == 20
-    assert doc.downloads.past24 == 30
-    assert doc.downloads.past48 == 40
-    assert doc.impressions.past1 == 0
-    assert doc.impressions.past12 == 0
-    assert doc.impressions.past24 == 7
-    assert doc.impressions.past48 == 9
+    assert doc.downloads.total == 999
+    assert doc._links["prx:podcast"].href =~ ~r/podcasts\/123/
   end
 
   defp test_episodes do
@@ -32,8 +26,6 @@ defmodule Castle.API.EpisodeViewTest do
   end
 
   defp test_episode(guid) do
-    %{feeder_episode: guid,
-      downloads_past1: 10, downloads_past12: 20, downloads_past24: 30, downloads_past48: 40,
-      impressions_past1: nil, impressions_past12: 0, impressions_past24: 7, impressions_past48: 9}
+    %{feeder_episode: guid, feeder_podcast: 123, count: 999}
   end
 end

--- a/test/views/api/podcast_view_test.exs
+++ b/test/views/api/podcast_view_test.exs
@@ -11,20 +11,13 @@ defmodule Castle.API.PodcastViewTest do
     assert doc.total == 2
     assert length(embedded) == 2
     assert hd(embedded).id == "foo"
-    assert hd(embedded).downloads.past1 == 10
+    assert hd(embedded).downloads.total == 999
   end
 
   test "show.json", %{conn: conn} do
     doc = render("show.json", %{conn: conn, podcast: test_podcast("foo"), meta: %{}})
     assert doc.id == "foo"
-    assert doc.downloads.past1 == 10
-    assert doc.downloads.past12 == 20
-    assert doc.downloads.past24 == 30
-    assert doc.downloads.past48 == 40
-    assert doc.impressions.past1 == 0
-    assert doc.impressions.past12 == 0
-    assert doc.impressions.past24 == 7
-    assert doc.impressions.past48 == 9
+    assert doc.downloads.total == 999
   end
 
   defp test_podcasts do
@@ -32,8 +25,6 @@ defmodule Castle.API.PodcastViewTest do
   end
 
   defp test_podcast(id) do
-    %{feeder_podcast: id,
-      downloads_past1: 10, downloads_past12: 20, downloads_past24: 30, downloads_past48: 40,
-      impressions_past1: nil, impressions_past12: 0, impressions_past24: 7, impressions_past48: 9}
+    %{feeder_podcast: id, feeder_episodes: ["guid1", "guid2"], count: 999}
   end
 end

--- a/web/controllers/api/episode_controller.ex
+++ b/web/controllers/api/episode_controller.ex
@@ -1,19 +1,16 @@
 defmodule Castle.API.EpisodeController do
   use Castle.Web, :controller
 
-  @redis Application.get_env(:castle, :redis)
-  @bigquery Application.get_env(:castle, :bigquery)
-
-  @index_ttl 900
-  @show_ttl 300
+  alias Castle.Rollup.Data.Totals, as: Totals
 
   def index(conn, _params) do
-    {episodes, meta} = @redis.cached "episode.index", @index_ttl, fn() -> @bigquery.episodes() end
-    render conn, "index.json", conn: conn, episodes: episodes, meta: meta
+    render conn, "index.json", conn: conn, episodes: Totals.episodes(), meta: %{cached: true}
   end
 
   def show(conn, %{"id" => id}) do
-    {episode, meta} = @redis.cached "episode.show.#{id}", @show_ttl, fn() -> @bigquery.episode(id) end
-    render conn, "show.json", conn: conn, episode: episode, meta: meta
+    case Totals.episode(id) do
+      nil -> send_resp conn, 404, "Episode #{id} not found"
+      ep -> render conn, "show.json", conn: conn, episode: ep, meta: %{cached: true}
+    end
   end
 end


### PR DESCRIPTION
See #24.

- [x] Create a redis "partition cache", that can cache/combine arbitrary queries with different TTLs
- [x] Create worker(s) to cache various queries to redis in the background
- [x] Framework for the controllers to retrieve redis results without knowing/caring how that data got into redis.
- [x] Speed up the index/show views for podcasts and episodes by only hitting rolled-up redis data.

The `totals_job.ex` is probably just the beginning for things we want to roll up from a background worker.  But will implement other dashboard-ish data from other PRs.