### PR TITLE
More geo groupings

### DIFF
--- a/lib/big_query.ex
+++ b/lib/big_query.ex
@@ -11,8 +11,8 @@ defmodule BigQuery do
   end
 
   defmodule Grouping do
-    @enforce_keys [:name, :table, :key, :display, :fkey, :limit]
-    defstruct [:name, :table, :key, :display, :fkey, limit: 10]
+    @enforce_keys [:name, :join, :groupby, :limit]
+    defstruct [:name, :join, :groupby, limit: 10]
   end
 
   defdelegate podcasts(), to: Podcasts, as: :list

--- a/lib/big_query/base/timestamp.ex
+++ b/lib/big_query/base/timestamp.ex
@@ -16,13 +16,13 @@ defmodule BigQuery.Base.Timestamp do
   end
 
   def timestamp_intervals(tbl, where_sql), do: timestamp_intervals(tbl, where_sql, nil)
-  def timestamp_intervals(tbl, where_sql, extra_fld) do
+  def timestamp_intervals(tbl, where_sql, extra_fld, joiner \\ "") do
     """
     SELECT
       TIMESTAMP_SECONDS(UNIX_SECONDS(timestamp) - MOD(UNIX_SECONDS(timestamp), @interval_s)) as time,
       #{comma_after(extra_fld)}
       COUNT(*) as count
-    FROM #{tbl}
+    FROM #{tbl} #{joiner}
     WHERE
       is_duplicate = false
       AND #{timestamp_partition()}

--- a/lib/plugs/group_plug.ex
+++ b/lib/plugs/group_plug.ex
@@ -4,42 +4,56 @@ defmodule Castle.Plugs.Group do
   @groups %{
     "city" => %{
       name: "city",
-      table: "geonames",
-      key: "geoname_id",
-      display: "city_name",
-      fkey: "city_id",
+      join: "geonames on (city_id = geoname_id)",
+      groupby: "city_name",
+      limit: 10,
+    },
+    "metrocode" => %{
+      name: "metrocode",
+      join: "geonames on (city_id = geoname_id)",
+      groupby: "metro_code",
+      limit: 10,
+    },
+    "subdiv1" => %{
+      name: "subdiv1",
+      join: "geonames on (city_id = geoname_id)",
+      groupby: "subdivision_1_iso_code",
+      limit: 10,
+    },
+    "subdiv2" => %{
+      name: "subdiv2",
+      join: "geonames on (city_id = geoname_id)",
+      groupby: "subdivision_2_iso_code",
       limit: 10,
     },
     "country" => %{
       name: "country",
-      table: "geonames",
-      key: "geoname_id",
-      display: "country_name",
-      fkey: "country_id",
+      join: "geonames on (country_id = geoname_id)",
+      groupby: "country_name",
+      limit: 10,
+    },
+    "countryiso" => %{
+      name: "country",
+      join: "geonames on (country_id = geoname_id)",
+      groupby: "country_iso_code",
       limit: 10,
     },
     "agentname" => %{
       name: "agentname",
-      table: "agentnames",
-      key: "agentname_id",
-      display: "tag",
-      fkey: "agent_name_id",
+      join: "agentnames on (agent_name_id = agentname_id)",
+      groupby: "tag",
       limit: 10
     },
     "agenttype" => %{
       name: "agenttype",
-      table: "agentnames",
-      key: "agentname_id",
-      display: "tag",
-      fkey: "agent_type_id",
+      join: "agentnames on (agent_type_id = agentname_id)",
+      groupby: "tag",
       limit: 10
     },
     "agentos" => %{
       name: "agentos",
-      table: "agentnames",
-      key: "agentname_id",
-      display: "tag",
-      fkey: "agent_os_id",
+      join: "agentnames on (agent_os_id = agentname_id)",
+      groupby: "tag",
       limit: 10
     },
   }

--- a/test/big_query/base/timestamp_group_test.exs
+++ b/test/big_query/base/timestamp_group_test.exs
@@ -4,14 +4,14 @@ defmodule Castle.BigQueryBaseTimestampGroupTest do
   import BigQuery.Base.TimestampGroup
 
   defp test_group() do
-    %BigQuery.Grouping{name: "foo", table: "join_table", key: "my_id",
-      display: "my_name", fkey: "your_id", limit: 1234}
+    %BigQuery.Grouping{name: "foo", join: "whatever on (hello = world)",
+      groupby: "your_group", limit: 1234}
   end
 
   test "joins the table" do
     sql = group_sql("the_table", "foo = @bar", test_group())
     assert sql =~ ~r/FROM the_table/
-    assert sql =~ ~r/JOIN join_table ON \(your_id = my_id\)/
+    assert sql =~ ~r/JOIN whatever on \(hello = world\)/
     assert sql =~ ~r/AND foo = @bar/
   end
 

--- a/test/plugs/group_plug_test.exs
+++ b/test/plugs/group_plug_test.exs
@@ -3,17 +3,17 @@ defmodule Castle.PlugsGroupTest do
 
   test "groups by country", %{conn: conn} do
     group = get_group(conn, "country")
-    assert group.key == "geoname_id"
-    assert group.fkey == "country_id"
-    assert group.display == "country_name"
+    assert group.name == "country"
+    assert group.join == "geonames on (country_id = geoname_id)"
+    assert group.groupby == "country_name"
     assert group.limit == 10
   end
 
   test "groups by city", %{conn: conn} do
     group = get_group(conn, "city")
-    assert group.key == "geoname_id"
-    assert group.fkey == "city_id"
-    assert group.display == "city_name"
+    assert group.name == "city"
+    assert group.join == "geonames on (city_id = geoname_id)"
+    assert group.groupby == "city_name"
     assert group.limit == 10
   end
 


### PR DESCRIPTION
See #23.

Refactor the `?group=` SQL to join the geonames/agentnames tables first, and then group.  Used to do it the other way around ... group by city_id/country_id/etc, and then join.  This seems to be nearly as quick, and consumes the same amount of query-MBs.

And added these `?group=` params: `metrocode` / `subdiv1` / `subdiv2` / `countryiso`.