### PR TITLE
Parse to UTC datetimes

### DIFF
--- a/lib/plugs/interval/time_from.ex
+++ b/lib/plugs/interval/time_from.ex
@@ -2,7 +2,7 @@ defmodule Castle.Plugs.Interval.TimeFrom do
 
   def parse(%{params: %{"from" => from_dtim}}) when is_bitstring(from_dtim) do
     case parse_dtim(from_dtim) do
-      {:ok, dtim} -> {:ok, dtim}
+      {:ok, dtim} -> {:ok, Timex.Timezone.convert(dtim, :utc)}
       {:error, _err} -> {:error, "Bad from param: must be a valid ISO8601 date"}
     end
   end

--- a/lib/plugs/interval/time_to.ex
+++ b/lib/plugs/interval/time_to.ex
@@ -5,7 +5,7 @@ defmodule Castle.Plugs.Interval.TimeTo do
 
   def parse(%{params: %{"to" => to_dtim}}) when is_bitstring(to_dtim) do
     case parse_dtim(to_dtim) do
-      {:ok, dtim} -> {:ok, dtim}
+      {:ok, dtim} -> {:ok, Timex.Timezone.convert(dtim, :utc)}
       {:error, _err} -> {:error, "Bad to param: must be a valid ISO8601 date"}
     end
   end

--- a/test/plugs/interval/time_from_test.exs
+++ b/test/plugs/interval/time_from_test.exs
@@ -11,6 +11,13 @@ defmodule Castle.PlugsIntervalTimeFromTest do
     assert Timex.to_unix(time_from) == 1491004800
   end
 
+  test "converts to utc", %{conn: conn} do
+    {:ok, time_from} = call_time_from(conn, "2017-04-01T08:04:11-06:00 Etc/GMT+6")
+    {:ok, offset} = Timex.format(time_from, "{Z}")
+    assert Timex.to_unix(time_from) == 1491055451
+    assert offset == "+0000"
+  end
+
   test "handles invalid params", %{conn: conn} do
     {:error, err} = call_time_from(conn, "3888385885")
     assert err =~ ~r/bad from param/i

--- a/test/plugs/interval/time_to_test.exs
+++ b/test/plugs/interval/time_to_test.exs
@@ -21,6 +21,13 @@ defmodule Castle.PlugsIntervalTimeToTest do
     assert Timex.to_unix(time_to) == 1491004800
   end
 
+  test "converts to utc", %{conn: conn} do
+    {:ok, time_to} = call_time_to(conn, "2017-04-01T08:04:11-06:00 Etc/GMT+6")
+    {:ok, offset} = Timex.format(time_to, "{Z}")
+    assert Timex.to_unix(time_to) == 1491055451
+    assert offset == "+0000"
+  end
+
   test "handles invalid params", %{conn: conn} do
     {:error, err} = call_time_to(conn, "3888385885")
     assert err =~ ~r/bad to param/i


### PR DESCRIPTION
Was parsing datetimes in whatever timezone they came in as, then sending that to BigQuery.  And it turned out, BQ doesn't like certain timezone strings.  So just convert everything to UTC on the way in.