### PR TITLE
Better downloads/impressions cache logic

### DIFF
--- a/lib/big_query.ex
+++ b/lib/big_query.ex
@@ -21,13 +21,13 @@ defmodule BigQuery do
   defdelegate episodes(), to: Episodes, as: :list
   defdelegate episode(guid), to: Episodes, as: :show
 
-  defdelegate podcast_downloads(id, interval), to: Downloads, as: :for_podcast
-  defdelegate podcast_downloads(id, interval, group), to: Downloads, as: :for_podcast
-  defdelegate podcast_impressions(id, interval), to: Impressions, as: :for_podcast
-  defdelegate podcast_impressions(id, interval, group), to: Impressions, as: :for_podcast
+  defdelegate podcast_downloads(interval), to: Downloads, as: :for_podcasts
+  defdelegate podcast_downloads(id, interval, group), to: Downloads, as: :group_podcast
+  defdelegate podcast_impressions(interval), to: Impressions, as: :for_podcasts
+  defdelegate podcast_impressions(id, interval, group), to: Impressions, as: :group_podcast
 
-  defdelegate episode_downloads(guid, interval), to: Downloads, as: :for_episode
-  defdelegate episode_downloads(guid, interval, group), to: Downloads, as: :for_episode
-  defdelegate episode_impressions(id, interval), to: Impressions, as: :for_episode
-  defdelegate episode_impressions(id, interval, group), to: Impressions, as: :for_episode
+  defdelegate episode_downloads(interval), to: Downloads, as: :for_episodes
+  defdelegate episode_downloads(guid, interval, group), to: Downloads, as: :group_episode
+  defdelegate episode_impressions(interval), to: Impressions, as: :for_episodes
+  defdelegate episode_impressions(guid, interval, group), to: Impressions, as: :group_episode
 end

--- a/lib/big_query/base/timestamp.ex
+++ b/lib/big_query/base/timestamp.ex
@@ -1,33 +1,24 @@
 defmodule BigQuery.Base.Timestamp do
   import BigQuery.Base.Query
 
-  def timestamp_query(tbl, where_sql, params, interval) do
-    params
-    |> timestamp_params(interval)
-    |> query(timestamp_sql(tbl, interval, where_sql))
+  def timestamp_query(tbl, interval, group_by) do
+    timestamp_params(interval) |> query(timestamp_sql(tbl, interval, group_by))
   end
 
-  def timestamp_sql(tbl, interval, where_sql) do
+  def timestamp_sql(tbl, interval, group_by) do
     """
-    WITH intervals AS (#{timestamp_intervals(tbl, interval, where_sql)})
-    SELECT time, count FROM intervals
-    ORDER BY time ASC
-    """
+    WITH intervals AS (#{timestamp_intervals(tbl, interval, group_by)})
+    SELECT time, #{group_by}, count FROM intervals
+    ORDER BY time ASC, #{group_by} ASC
+    """ |> clean_sql()
   end
 
-  def timestamp_intervals(tbl, interval, where_sql), do: timestamp_intervals(tbl, interval, where_sql, nil)
-  def timestamp_intervals(tbl, interval, where_sql, extra_fld, joiner \\ "") do
+  def timestamp_intervals(tbl, interval, group_by) do
     """
-    SELECT
-      #{interval.rollup.rollup()} as time,
-      #{comma_after(extra_fld)}
-      COUNT(*) as count
-    FROM #{tbl} #{joiner}
-    WHERE
-      is_duplicate = false
-      AND #{timestamp_partition()}
-      AND #{where_sql}
-    GROUP BY time#{comma_before(extra_fld)}
+    SELECT #{interval.rollup.rollup()} as time, #{group_by}, COUNT(*) as count
+    FROM #{tbl}
+    WHERE is_duplicate = false AND #{timestamp_partition()}
+    GROUP BY time, #{group_by}
     """
   end
 
@@ -35,17 +26,16 @@ defmodule BigQuery.Base.Timestamp do
     "timestamp >= @from_dtim AND timestamp < @to_dtim AND _PARTITIONTIME >= @pstart AND _PARTITIONTIME <= @pend"
   end
 
-  def timestamp_params(params, interval) do
-    params
-    |> Map.put(:from_dtim, interval.from)
-    |> Map.put(:to_dtim, interval.to)
-    |> Map.put(:pstart, Timex.beginning_of_day(interval.from))
-    |> Map.put(:pend, Timex.end_of_day(interval.to))
+  def timestamp_params(interval) do
+    %{
+      from_dtim: interval.from,
+      to_dtim: interval.to,
+      pstart: Timex.beginning_of_day(interval.from),
+      pend: Timex.end_of_day(interval.to),
+    }
   end
 
-  defp comma_after(nil), do: ""
-  defp comma_after(fld), do: "#{fld},"
-
-  defp comma_before(nil), do: ""
-  defp comma_before(fld), do: ", #{fld}"
+  def clean_sql(str) do
+    Regex.replace(~r/[ \n\r\t]+/, str, " ")
+  end
 end

--- a/lib/big_query/base/timestamp_group.ex
+++ b/lib/big_query/base/timestamp_group.ex
@@ -1,17 +1,17 @@
 defmodule BigQuery.Base.TimestampGroup do
   import BigQuery.Base.Query
   import BigQuery.Base.Timestamp,
-    only: [timestamp_intervals: 5, timestamp_params: 2]
+    only: [timestamp_params: 1, timestamp_partition: 0, clean_sql: 1]
 
   def group_query(tbl, where_sql, params, interval, grouping) do
     params
-    |> timestamp_params(interval)
+    |> Map.merge(timestamp_params(interval))
     |> group_params(grouping)
     |> query(group_sql(tbl, interval, where_sql, grouping))
   end
 
   def group_sql(tbl, interval, where_sql, grouping) do
-    intervals = timestamp_intervals(tbl, interval, where_sql, grouping.groupby, "JOIN #{grouping.join}")
+    intervals = group_intervals(tbl, interval, grouping, where_sql)
     """
     WITH
       intervals AS (#{intervals}),
@@ -25,7 +25,7 @@ defmodule BigQuery.Base.TimestampGroup do
     LEFT JOIN top_groups USING (#{grouping.groupby})
     GROUP BY time, rank
     ORDER BY time asc, rank asc
-    """
+    """ |> clean_sql()
   end
 
   def group_params(params, grouping) do
@@ -43,6 +43,21 @@ defmodule BigQuery.Base.TimestampGroup do
       FROM #{tbl}
       WHERE #{key} IS NOT NULL
     ) as top_groups, UNNEST(tops)
+    """
+  end
+
+  def group_intervals(tbl, interval, grouping, where_sql) do
+    """
+    SELECT
+      #{interval.rollup.rollup()} as time,
+      #{grouping.groupby},
+      COUNT(*) as count
+    FROM #{tbl} JOIN #{grouping.join}
+    WHERE
+      is_duplicate = false
+      AND #{timestamp_partition()}
+      AND #{where_sql}
+    GROUP BY time, #{grouping.groupby}
     """
   end
 end

--- a/lib/big_query/downloads.ex
+++ b/lib/big_query/downloads.ex
@@ -2,17 +2,15 @@ defmodule BigQuery.Downloads do
   import BigQuery.Base.Timestamp
   import BigQuery.Base.TimestampGroup
 
-  def for_podcast(podcast_id, interval) do
-    timestamp_query(
-      Env.get(:bq_downloads_table),
-      "feeder_podcast = @podcast_id",
-      %{podcast_id: podcast_id},
-      interval
-    )
+  def for_podcasts(interval) do
+    timestamp_query(Env.get(:bq_downloads_table), interval, "feeder_podcast")
   end
 
-  def for_podcast(podcast_id, interval, nil), do: for_podcast(podcast_id, interval)
-  def for_podcast(podcast_id, interval, group) do
+  def for_episodes(interval) do
+    timestamp_query(Env.get(:bq_downloads_table), interval, "feeder_episode")
+  end
+
+  def group_podcast(podcast_id, interval, group) do
     group_query(
       Env.get(:bq_downloads_table),
       "feeder_podcast = @podcast_id",
@@ -22,17 +20,7 @@ defmodule BigQuery.Downloads do
     )
   end
 
-  def for_episode(episode_guid, interval) do
-    timestamp_query(
-      Env.get(:bq_downloads_table),
-      "feeder_episode = @episode_guid",
-      %{episode_guid: episode_guid},
-      interval
-    )
-  end
-
-  def for_episode(episode_guid, interval, nil), do: for_episode(episode_guid, interval)
-  def for_episode(episode_guid, interval, group) do
+  def group_episode(episode_guid, interval, group) do
     group_query(
       Env.get(:bq_downloads_table),
       "feeder_episode = @episode_guid",

--- a/lib/big_query/impressions.ex
+++ b/lib/big_query/impressions.ex
@@ -2,17 +2,15 @@ defmodule BigQuery.Impressions do
   import BigQuery.Base.Timestamp
   import BigQuery.Base.TimestampGroup
 
-  def for_podcast(podcast_id, interval) do
-    timestamp_query(
-      Env.get(:bq_impressions_table),
-      "feeder_podcast = @podcast_id",
-      %{podcast_id: podcast_id},
-      interval
-    )
+  def for_podcasts(interval) do
+    timestamp_query(Env.get(:bq_impressions_table), interval, "feeder_podcast")
   end
 
-  def for_podcast(podcast_id, interval, nil), do: for_podcast(podcast_id, interval)
-  def for_podcast(podcast_id, interval, group) do
+  def for_episodes(interval) do
+    timestamp_query(Env.get(:bq_impressions_table), interval, "feeder_episode")
+  end
+
+  def group_podcast(podcast_id, interval, group) do
     group_query(
       Env.get(:bq_impressions_table),
       "feeder_podcast = @podcast_id",
@@ -22,17 +20,7 @@ defmodule BigQuery.Impressions do
     )
   end
 
-  def for_episode(episode_guid, interval) do
-    timestamp_query(
-      Env.get(:bq_impressions_table),
-      "feeder_episode = @episode_guid",
-      %{episode_guid: episode_guid},
-      interval
-    )
-  end
-
-  def for_episode(episode_guid, interval, nil), do: for_episode(episode_guid, interval)
-  def for_episode(episode_guid, interval, group) do
+  def group_episode(episode_guid, interval, group) do
     group_query(
       Env.get(:bq_impressions_table),
       "feeder_episode = @episode_guid",

--- a/lib/redis.ex
+++ b/lib/redis.ex
@@ -31,23 +31,13 @@ defmodule Castle.Redis do
   ) :: result
 
   @doc """
-  Cache intervals with a from/to/seconds object, instead of explicit params.
-  """
-  @callback interval(
-    key_prefix :: String.t,
-    intv       :: interval,
-    work_fn    :: (new_from :: %DateTime{} -> result)
-  ) :: result
-
-  @doc """
   Cache a list of intervals for a time range. The worker function will be called
   with a different from-dtim if there were any cache hits.
   """
   @callback interval(
     key_prefix :: String.t,
-    from       :: %DateTime{},
-    to         :: %DateTime{},
-    interval   :: pos_integer(),
+    intv       :: interval,
+    identifier :: String.t,
     work_fn    :: (new_from :: %DateTime{} -> result)
   ) :: result
 

--- a/lib/redis/api.ex
+++ b/lib/redis/api.ex
@@ -5,11 +5,7 @@ defmodule Castle.Redis.Api do
     to: Castle.Redis.ResponseCache,
     as: :cached
 
-  defdelegate interval(key_prefix, intv, work_fn),
-    to: Castle.Redis.IntervalCache,
-    as: :interval
-
-  defdelegate interval(key_prefix, from, to, interval, work_fn),
+  defdelegate interval(key_prefix, intv, identifier, work_fn),
     to: Castle.Redis.IntervalCache,
     as: :interval
 

--- a/lib/redis/interval/getter.ex
+++ b/lib/redis/interval/getter.ex
@@ -1,0 +1,34 @@
+defmodule Castle.Redis.Interval.Getter do
+  alias Castle.Redis.Conn, as: Conn
+  alias Castle.Redis.Interval.Keys, as: Keys
+
+  @buffer_seconds 30
+
+  def get(key_prefix, ident, from, to, rollup) do
+    range = rollup.range(from, to, false)
+    counts = Keys.keys(key_prefix, range) |> Conn.hget(ident)
+    cache_hits(range, counts)
+  end
+
+  defp cache_hits(times, counts), do: cache_hits(times, counts, [])
+  defp cache_hits([time | rest_times], [count | rest_counts], accumulator) do
+    case cache_val(time, count) do
+      nil -> {accumulator, time}
+      val -> cache_hits(rest_times, rest_counts, accumulator ++ [val])
+    end
+  end
+  defp cache_hits(_out_of_times, _out_of_counts, accumulator) do
+    {accumulator, nil}
+  end
+
+  def cache_val(time, [true, nil]), do: %{time: time, count: 0}
+  def cache_val(time, [true, val]), do: %{time: time, count: val}
+  def cache_val(time, [false, _val]) do
+    elapsed = Timex.to_unix(Timex.now) - Timex.to_unix(time)
+    if elapsed > @buffer_seconds do
+      nil # miss
+    else
+      %{time: time, count: 0}
+    end
+  end
+end

--- a/lib/redis/interval/keys.ex
+++ b/lib/redis/interval/keys.ex
@@ -1,0 +1,14 @@
+defmodule Castle.Redis.Interval.Keys do
+  def keys(prefix, date_range) do
+    Enum.map(date_range, &(key(prefix, &1)))
+  end
+
+  def key(prefix, dtim) do
+    "#{prefix}.#{format(dtim)}"
+  end
+
+  defp format(dtim) do
+    {:ok, formatted} = Timex.format(dtim, "{ISO:Extended:Z}")
+    formatted
+  end
+end

--- a/lib/redis/interval/setter.ex
+++ b/lib/redis/interval/setter.ex
@@ -1,0 +1,27 @@
+defmodule Castle.Redis.Interval.Setter do
+  alias Castle.Redis.Conn, as: Conn
+  alias Castle.Redis.Interval.Keys, as: Keys
+
+  @past_interval_ttl 0 # forever
+  @current_interval_ttl 300
+  @current_interval_buffer 3600
+
+  def past_interval_ttl, do: @past_interval_ttl
+  def current_interval_ttl, do: @current_interval_ttl
+
+  def set(_key_prefix, _from, _to, []), do: []
+  def set(key_prefix, from, to, counts) do
+    key = Keys.key(key_prefix, from)
+    ttl = interval_ttl(to)
+    Conn.hsetall(key, counts, ttl)
+  end
+
+  def interval_ttl(interval_end) do
+    cutoff = Timex.now() |> Timex.shift(seconds: -@current_interval_buffer)
+    if Timex.compare(cutoff, interval_end) < 0 do
+      @current_interval_ttl
+    else
+      @past_interval_ttl
+    end
+  end
+end

--- a/lib/redis/interval_cache.ex
+++ b/lib/redis/interval_cache.ex
@@ -1,5 +1,4 @@
 defmodule Castle.Redis.IntervalCache do
-  alias Castle.Redis.Conn, as: Conn
   alias Castle.Redis.Interval.{Getter, Setter}
 
   def interval(key_prefix, intv, ident, work_fn) do
@@ -17,7 +16,7 @@ defmodule Castle.Redis.IntervalCache do
     end
   end
 
-  defp run_work(work_fn, intv, key_prefix, ident) do
+  def run_work(work_fn, intv, key_prefix, ident) do
     {data, meta} = work_fn.(intv)
 
     # bulk set all the %{ident => counts}
@@ -30,9 +29,9 @@ defmodule Castle.Redis.IntervalCache do
     {filter_work(data, ident), meta}
   end
 
-  defp filter_work([{time, ids_to_counts} | rest], ident) do
+  def filter_work([{time, ids_to_counts} | rest], ident) do
     count = Map.get(ids_to_counts, ident, 0)
     [%{time: time, count: count}] ++ filter_work(rest, ident)
   end
-  defp filter_work([], ident), do: []
+  def filter_work([], _ident), do: []
 end

--- a/test/big_query/base/timestamp_test.exs
+++ b/test/big_query/base/timestamp_test.exs
@@ -24,14 +24,62 @@ defmodule Castle.BigQueryBaseTimestampTest do
   end
 
   test "sets params" do
-    {:ok, start, _} = DateTime.from_iso8601("2017-03-22T21:54:52Z")
-    {:ok, finish, _} = DateTime.from_iso8601("2017-03-28T04:12:00Z")
-    interval = %BigQuery.Interval{from: start, to: finish, rollup: 900}
+    start = get_dtim("2017-03-22T21:54:52Z")
+    finish = get_dtim("2017-03-28T04:12:00Z")
+    interval = %BigQuery.Interval{from: start, to: finish, rollup: BigQuery.TimestampRollups.QuarterHourly}
     params = timestamp_params(interval)
 
-    assert Timex.to_unix(params.from_dtim) == 1490219692
-    assert Timex.to_unix(params.to_dtim) == 1490674320
-    assert Timex.to_unix(params.pstart) == 1490140800
-    assert Timex.to_unix(params.pend) == 1490745599
+    assert_time params.from_dtim, "2017-03-22T21:54:52Z"
+    assert_time params.to_dtim, "2017-03-28T04:12:00Z"
+    assert_time params.pstart, "2017-03-22T00:00:00Z"
+    assert_time params.pend, "2017-03-28T23:59:59.999999Z"
+  end
+
+  test "groups results" do
+    start = get_dtim("2017-03-28T04:00:00Z")
+    finish = get_dtim("2017-03-28T11:00:00Z")
+    interval = %BigQuery.Interval{from: start, to: finish, rollup: BigQuery.TimestampRollups.Hourly}
+    raw = [
+      %{time: get_dtim("2017-03-28T05:00:00Z"), feeder_podcast: 123, count: 11},
+      %{time: get_dtim("2017-03-28T06:00:00Z"), feeder_podcast: 456, count: 22},
+      %{time: get_dtim("2017-03-28T06:00:00Z"), feeder_podcast: 123, count: 33},
+      %{time: get_dtim("2017-03-28T07:00:00Z"), feeder_podcast: 123, count: 44},
+      %{time: get_dtim("2017-03-28T09:00:00Z"), feeder_podcast: 456, count: 55},
+      %{time: get_dtim("2017-03-28T09:00:00Z"), feeder_podcast: 789, count: 66},
+    ]
+    {data, _meta} = group({raw, %{}}, interval, "feeder_podcast")
+
+    assert length(data) == 7
+    assert_time Enum.at(data, 0), "2017-03-28T04:00:00Z"
+    assert_time Enum.at(data, 1), "2017-03-28T05:00:00Z"
+    assert_time Enum.at(data, 2), "2017-03-28T06:00:00Z"
+    assert_time Enum.at(data, 3), "2017-03-28T07:00:00Z"
+    assert_time Enum.at(data, 4), "2017-03-28T08:00:00Z"
+    assert_time Enum.at(data, 5), "2017-03-28T09:00:00Z"
+    assert_time Enum.at(data, 6), "2017-03-28T10:00:00Z"
+
+    assert get_counts(data, 0) == %{}
+    assert get_counts(data, 1) == %{123 => 11}
+    assert get_counts(data, 2) == %{123 => 33, 456 => 22}
+    assert get_counts(data, 3) == %{123 => 44}
+    assert get_counts(data, 4) == %{}
+    assert get_counts(data, 5) == %{456 => 55, 789 => 66}
+    assert get_counts(data, 6) == %{}
+  end
+
+  defp get_dtim(dtim_str) do
+    {:ok, dtim, _} = DateTime.from_iso8601(dtim_str)
+    dtim
+  end
+
+  defp assert_time({dtim, _map}, expected_str), do: assert_time(dtim, expected_str)
+  defp assert_time(dtim, expected_str) do
+    {:ok, formatted} = Timex.format(dtim, "{ISO:Extended:Z}")
+    assert formatted == expected_str
+  end
+
+  defp get_counts(data, at) do
+    {_time, counts} = Enum.at(data, at)
+    counts
   end
 end

--- a/test/big_query/base/timestamp_test.exs
+++ b/test/big_query/base/timestamp_test.exs
@@ -1,5 +1,6 @@
 defmodule Castle.BigQueryBaseTimestampTest do
   use Castle.BigQueryCase, async: true
+  use Castle.TimeHelpers
 
   import BigQuery.Base.Timestamp
 
@@ -50,13 +51,14 @@ defmodule Castle.BigQueryBaseTimestampTest do
     {data, _meta} = group({raw, %{}}, interval, "feeder_podcast")
 
     assert length(data) == 7
-    assert_time Enum.at(data, 0), "2017-03-28T04:00:00Z"
-    assert_time Enum.at(data, 1), "2017-03-28T05:00:00Z"
-    assert_time Enum.at(data, 2), "2017-03-28T06:00:00Z"
-    assert_time Enum.at(data, 3), "2017-03-28T07:00:00Z"
-    assert_time Enum.at(data, 4), "2017-03-28T08:00:00Z"
-    assert_time Enum.at(data, 5), "2017-03-28T09:00:00Z"
-    assert_time Enum.at(data, 6), "2017-03-28T10:00:00Z"
+    times = Enum.map(data, fn(d) -> List.first(Tuple.to_list(d)) end)
+    assert_time times, 0, "2017-03-28T04:00:00Z"
+    assert_time times, 1, "2017-03-28T05:00:00Z"
+    assert_time times, 2, "2017-03-28T06:00:00Z"
+    assert_time times, 3, "2017-03-28T07:00:00Z"
+    assert_time times, 4, "2017-03-28T08:00:00Z"
+    assert_time times, 5, "2017-03-28T09:00:00Z"
+    assert_time times, 6, "2017-03-28T10:00:00Z"
 
     assert get_counts(data, 0) == %{}
     assert get_counts(data, 1) == %{123 => 11}
@@ -65,17 +67,6 @@ defmodule Castle.BigQueryBaseTimestampTest do
     assert get_counts(data, 4) == %{}
     assert get_counts(data, 5) == %{456 => 55, 789 => 66}
     assert get_counts(data, 6) == %{}
-  end
-
-  defp get_dtim(dtim_str) do
-    {:ok, dtim, _} = DateTime.from_iso8601(dtim_str)
-    dtim
-  end
-
-  defp assert_time({dtim, _map}, expected_str), do: assert_time(dtim, expected_str)
-  defp assert_time(dtim, expected_str) do
-    {:ok, formatted} = Timex.format(dtim, "{ISO:Extended:Z}")
-    assert formatted == expected_str
   end
 
   defp get_counts(data, at) do

--- a/test/big_query/base/timestamp_test.exs
+++ b/test/big_query/base/timestamp_test.exs
@@ -6,19 +6,20 @@ defmodule Castle.BigQueryBaseTimestampTest do
   @fifteen %{rollup: BigQuery.TimestampRollups.QuarterHourly}
   @weekly %{rollup: BigQuery.TimestampRollups.Weekly}
 
-  test "adds a where condition" do
-    sql = timestamp_sql("the_table", @fifteen, "foo = @bar")
+  test "groups by a param" do
+    sql = timestamp_sql("the_table", @fifteen, "feeder_podcast")
     assert sql =~ ~r/FROM the_table/
-    assert sql =~ ~r/AND foo = @bar/
+    assert sql =~ ~r/GROUP BY time, feeder_podcast/
+    assert sql =~ ~r/SELECT time, feeder_podcast, count/
   end
 
   test "uses a modulo based rollup" do
-    sql = timestamp_sql("the_table", @fifteen, "foo = @bar")
+    sql = timestamp_sql("the_table", @fifteen, "feeder_podcast")
     assert sql =~ ~r/MOD\(UNIX_SECONDS\(timestamp\), 900/
   end
 
   test "uses a truncation rollup" do
-    sql = timestamp_sql("the_table", @weekly, "foo = @bar")
+    sql = timestamp_sql("the_table", @weekly, "feeder_podcast")
     assert sql =~ ~r/TIMESTAMP_TRUNC\(timestamp, WEEK/
   end
 
@@ -26,7 +27,7 @@ defmodule Castle.BigQueryBaseTimestampTest do
     {:ok, start, _} = DateTime.from_iso8601("2017-03-22T21:54:52Z")
     {:ok, finish, _} = DateTime.from_iso8601("2017-03-28T04:12:00Z")
     interval = %BigQuery.Interval{from: start, to: finish, rollup: 900}
-    params = timestamp_params(%{}, interval)
+    params = timestamp_params(interval)
 
     assert Timex.to_unix(params.from_dtim) == 1490219692
     assert Timex.to_unix(params.to_dtim) == 1490674320

--- a/test/big_query/downloads_test.exs
+++ b/test/big_query/downloads_test.exs
@@ -10,11 +10,13 @@ defmodule Castle.BigQueryDownloadsTest do
     {result, _meta} = for_podcasts(intv)
 
     assert is_list result
-    assert length(result) > 400
-    assert hd(result).time
-    assert_time result, 0, "2017-06-27T21:45:00Z"
-    assert hd(result).feeder_podcast == 3
-    assert hd(result).count > 0
+    assert length(result) == 26
+
+    {time, counts} = Enum.at(result, 0)
+    assert_time time, "2017-06-27T21:45:00Z"
+    assert length(Map.keys(counts)) > 10
+    assert Map.has_key?(counts, 57)
+    assert Map.get(counts, 57) == 1710
   end
 
   test "groups downloads for a podcast" do
@@ -46,11 +48,15 @@ defmodule Castle.BigQueryDownloadsTest do
     {result, _meta} = for_episodes(intv)
 
     assert is_list result
-    assert length(result) > 400
-    assert hd(result).time
-    assert_time result, 0, "2017-06-27T21:45:00Z"
-    assert hd(result).feeder_episode == "003854ff-a28e-4ebd-a6de-31df914f7f60"
-    assert hd(result).count > 0
+    assert length(result) == 26
+
+    {time1, counts} = Enum.at(result, 0)
+    {time2, _counts} = Enum.at(result, 1)
+    assert_time time1, "2017-06-27T21:45:00Z"
+    assert_time time2, "2017-06-27T22:00:00Z"
+    assert length(Map.keys(counts)) > 10
+    assert Map.has_key?(counts, "e4f5a88b-b383-493a-b7f3-8b8ea52cbf35")
+    assert Map.get(counts, "e4f5a88b-b383-493a-b7f3-8b8ea52cbf35") == 234
   end
 
   test "groups downloads for an episode" do

--- a/test/big_query/downloads_test.exs
+++ b/test/big_query/downloads_test.exs
@@ -1,5 +1,6 @@
 defmodule Castle.BigQueryDownloadsTest do
   use Castle.BigQueryCase, async: true
+  use Castle.TimeHelpers
 
   @moduletag :external
 

--- a/test/big_query/impressions_test.exs
+++ b/test/big_query/impressions_test.exs
@@ -5,21 +5,22 @@ defmodule Castle.BigQueryImpressionsTest do
 
   import BigQuery.Impressions
 
-  test "lists impressions for a podcast" do
+  test "lists impressions for all podcasts" do
     intv = interval("2017-06-27T21:45:00Z", "2017-06-28T04:15:00Z", BigQuery.TimestampRollups.QuarterHourly)
-    {result, _meta} = for_podcast(57, intv)
+    {result, _meta} = for_podcasts(intv)
 
     assert is_list result
-    assert length(result) == 26
+    assert length(result) > 400
     assert hd(result).time
-    assert Timex.to_unix(hd(result).time) == 1498599900
+    assert_time result, 0, "2017-06-27T21:45:00Z"
+    assert hd(result).feeder_podcast == 3
     assert hd(result).count > 0
   end
 
-  test "groups impressions by city for a podcast" do
+  test "groups impressions for a podcast" do
     intv = interval("2017-07-10T21:45:00Z", "2017-07-11T04:15:00Z", BigQuery.TimestampRollups.QuarterHourly)
     group = Castle.Plugs.Group.get("city", 3)
-    {result, _meta} = for_podcast(57, intv, group)
+    {result, _meta} = group_podcast(57, intv, group)
     assert is_list result
     assert length(result) == 26 * 4
 
@@ -39,14 +40,35 @@ defmodule Castle.BigQueryImpressionsTest do
     assert Enum.at(result, 7).display == Enum.at(result, 3).display
   end
 
-  test "lists impressions for an episode" do
+  test "lists impressions for all episodes" do
     intv = interval("2017-06-27T21:45:00Z", "2017-06-28T04:15:00Z", BigQuery.TimestampRollups.Hourly)
-    {result, _meta} = for_episode("7acf74b8-7b0a-4e9e-90be-f69052064b77", intv)
+    {result, _meta} = for_episodes(intv)
 
     assert is_list result
-    assert length(result) == 8
+    assert length(result) > 400
     assert hd(result).time
     assert_time result, 0, "2017-06-27T21:00:00Z"
+    assert hd(result).feeder_episode == "003854ff-a28e-4ebd-a6de-31df914f7f60"
     assert hd(result).count > 0
+  end
+
+  test "groups impressions for an episode" do
+    intv = interval("2017-07-10T04:00:00Z", "2017-07-10T22:00:00Z", BigQuery.TimestampRollups.Hourly)
+    group = Castle.Plugs.Group.get("country", 2)
+    {result, _meta} = group_episode("7acf74b8-7b0a-4e9e-90be-f69052064b77", intv, group)
+    assert is_list result
+    assert length(result) == 18 * 3
+
+    assert_time result, 0, "2017-07-10T04:00:00Z"
+    assert_time result, 1, "2017-07-10T04:00:00Z"
+    assert_time result, 2, "2017-07-10T04:00:00Z"
+    assert_time result, 3, "2017-07-10T05:00:00Z"
+
+    assert Enum.at(result, 0).display == nil
+    assert Enum.at(result, 1).display != nil
+    assert Enum.at(result, 2).display != nil
+    assert Enum.at(result, 3).display == nil
+    assert Enum.at(result, 4).display == Enum.at(result, 1).display
+    assert Enum.at(result, 5).display == Enum.at(result, 2).display
   end
 end

--- a/test/big_query/impressions_test.exs
+++ b/test/big_query/impressions_test.exs
@@ -10,11 +10,13 @@ defmodule Castle.BigQueryImpressionsTest do
     {result, _meta} = for_podcasts(intv)
 
     assert is_list result
-    assert length(result) > 400
-    assert hd(result).time
-    assert_time result, 0, "2017-06-27T21:45:00Z"
-    assert hd(result).feeder_podcast == 3
-    assert hd(result).count > 0
+    assert length(result) == 26
+
+    {time, counts} = Enum.at(result, 0)
+    assert_time time, "2017-06-27T21:45:00Z"
+    assert length(Map.keys(counts)) > 10
+    assert Map.has_key?(counts, 57)
+    assert Map.get(counts, 57) == 7134
   end
 
   test "groups impressions for a podcast" do
@@ -45,11 +47,13 @@ defmodule Castle.BigQueryImpressionsTest do
     {result, _meta} = for_episodes(intv)
 
     assert is_list result
-    assert length(result) > 400
-    assert hd(result).time
-    assert_time result, 0, "2017-06-27T21:00:00Z"
-    assert hd(result).feeder_episode == "003854ff-a28e-4ebd-a6de-31df914f7f60"
-    assert hd(result).count > 0
+    assert length(result) == 8
+
+    {time, counts} = Enum.at(result, 0)
+    assert_time time, "2017-06-27T21:00:00Z"
+    assert length(Map.keys(counts)) > 10
+    assert Map.has_key?(counts, "7acf74b8-7b0a-4e9e-90be-f69052064b77")
+    assert Map.get(counts, "7acf74b8-7b0a-4e9e-90be-f69052064b77") == 1056
   end
 
   test "groups impressions for an episode" do

--- a/test/big_query/impressions_test.exs
+++ b/test/big_query/impressions_test.exs
@@ -1,5 +1,6 @@
 defmodule Castle.BigQueryImpressionsTest do
   use Castle.BigQueryCase, async: true
+  use Castle.TimeHelpers
 
   @moduletag :external
 

--- a/test/controllers/api/download_controller_test.exs
+++ b/test/controllers/api/download_controller_test.exs
@@ -77,32 +77,33 @@ defmodule Castle.API.DownloadControllerTest do
 
   defp fake_data do
     [
-      podcast_downloads: &downloads/2,
-      episode_downloads: &downloads/2,
+      podcast_downloads: &downloads/1,
+      episode_downloads: &downloads/1,
     ]
   end
 
   defp fake_groups do
     [
-      podcast_downloads: &downloads/3,
-      episode_downloads: &downloads/3,
+      podcast_downloads: &group_downloads/3,
+      episode_downloads: &group_downloads/3,
     ]
   end
 
-  defp downloads(id, interval, _group) do
-    {data, meta} = downloads(id, interval)
-    {
-      Enum.map(data, &(Map.merge(&1, %{display: "foo", rank: 1}))),
-      meta
-    }
+  defp group_downloads(_id, _interval, _group) do
+    {:ok, start, _} = DateTime.from_iso8601("2017-03-22T00:00:00Z")
+    {Enum.map(0..19, &group_download(&1, start)), %{meta: "data"}}
   end
 
-  defp downloads(_id, _interval) do
+  defp group_download(num, start_dtim) do
+    %{count: num, time: Timex.shift(start_dtim, minutes: num * 900), display: "foo", rank: 1}
+  end
+
+  defp downloads(_interval) do
     {:ok, start, _} = DateTime.from_iso8601("2017-03-22T00:00:00Z")
     {Enum.map(0..19, &download(&1, start)), %{meta: "data"}}
   end
 
   defp download(num, start_dtim) do
-    %{count: num, time: Timex.shift(start_dtim, minutes: num * 900)}
+    {Timex.shift(start_dtim, minutes: num * 900), %{123 => num, "hello" => num}}
   end
 end

--- a/test/redis/conn_test.exs
+++ b/test/redis/conn_test.exs
@@ -26,6 +26,17 @@ defmodule Castle.RedisConnTest do
     assert get(keys) == ["someval", %{other: "val"}, nil]
   end
 
+  test "gets and sets hashes" do
+    assert hget(["conn_test_key1"], "f1") == [[false, nil]]
+    hsetall("conn_test_key1", %{f1: 999, f3: 777})
+    assert hget(["conn_test_key1"], "f1") == [[true, 999]]
+    assert hget(["conn_test_key1"], "f2") == [[true, nil]]
+    assert hget(["conn_test_key1", "conn_test_key2"], "f1") == [[true, 999], [false, nil]]
+    assert hget(["conn_test_key1", "conn_test_key2"], "f2") == [[true, nil], [false, nil]]
+    hsetall("conn_test_key1", %{f3: 777})
+    assert hget(["conn_test_key1"], "f1") == [[true, nil]]
+  end
+
   test "deletes objects" do
     assert set("conn_test_key1", 1234) == 1234
     assert get("conn_test_key1") == 1234

--- a/test/redis/conn_test.exs
+++ b/test/redis/conn_test.exs
@@ -37,6 +37,15 @@ defmodule Castle.RedisConnTest do
     assert hget(["conn_test_key1"], "f1") == [[true, nil]]
   end
 
+  test "sets empty hashes with ttl" do
+    assert hget(["conn_test_key1"], "f1") == [[false, nil]]
+    hsetall("conn_test_key1", %{})
+    assert hget(["conn_test_key1"], "f1") == [[true, nil]]
+    assert command(["TTL", "conn_test_key1"]) == -1
+    hsetall("conn_test_key1", %{}, 10)
+    assert command(["TTL", "conn_test_key1"]) == 10
+  end
+
   test "deletes objects" do
     assert set("conn_test_key1", 1234) == 1234
     assert get("conn_test_key1") == 1234

--- a/test/redis/interval_cache/getter_test.exs
+++ b/test/redis/interval_cache/getter_test.exs
@@ -21,11 +21,11 @@ defmodule Castle.RedisIntervalCacheGetterTest do
   end
 
   test "hits the entire range", %{from: from, to: to, rollup: rollup, keys: keys} do
-    Conn.hset(Enum.at(keys, 0), "key1", 11)
-    Conn.hset(Enum.at(keys, 1), "key1", 22)
-    Conn.hset(Enum.at(keys, 2), "key1", 33)
-    Conn.hset(Enum.at(keys, 3), "key1", 44)
-    {hits, new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+    Conn.hset(Enum.at(keys, 0), "field1", 11)
+    Conn.hset(Enum.at(keys, 1), "field1", 22)
+    Conn.hset(Enum.at(keys, 2), "field1", 33)
+    Conn.hset(Enum.at(keys, 3), "field1", 44)
+    {hits, new_from} = Getter.get(@prefix, "field1", from, to, rollup)
 
     assert length(hits) == 4
     assert new_from == nil
@@ -40,10 +40,10 @@ defmodule Castle.RedisIntervalCacheGetterTest do
   end
 
   test "misses a partial range", %{from: from, to: to, rollup: rollup, keys: keys} do
-    Conn.hset(Enum.at(keys, 0), "key1", 11)
-    Conn.hset(Enum.at(keys, 1), "key1", 22)
-    Conn.hset(Enum.at(keys, 3), "key1", 44)
-    {hits, new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+    Conn.hset(Enum.at(keys, 0), "field1", 11)
+    Conn.hset(Enum.at(keys, 1), "field1", 22)
+    Conn.hset(Enum.at(keys, 3), "field1", 44)
+    {hits, new_from} = Getter.get(@prefix, "field1", from, to, rollup)
 
     assert length(hits) == 2
     assert_time new_from, "2017-03-22T01:45:00Z"
@@ -54,19 +54,19 @@ defmodule Castle.RedisIntervalCacheGetterTest do
   end
 
   test "misses the entire range", %{from: from, to: to, rollup: rollup, keys: keys} do
-    Conn.hset(Enum.at(keys, 1), "key1", 22)
-    Conn.hset(Enum.at(keys, 2), "key1", 33)
-    Conn.hset(Enum.at(keys, 3), "key1", 44)
-    {hits, new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+    Conn.hset(Enum.at(keys, 1), "field1", 22)
+    Conn.hset(Enum.at(keys, 2), "field1", 33)
+    Conn.hset(Enum.at(keys, 3), "field1", 44)
+    {hits, new_from} = Getter.get(@prefix, "field1", from, to, rollup)
     assert hits == []
     assert_time new_from, "2017-03-22T01:15:00Z"
   end
 
   test "interprets hash-field misses as 0", %{from: from, to: to, rollup: rollup, keys: keys} do
-    Conn.hset(Enum.at(keys, 0), "key1", 11)
-    Conn.hset(Enum.at(keys, 1), "key2", 99)
-    Conn.hset(Enum.at(keys, 3), "key1", 44)
-    {hits, new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+    Conn.hset(Enum.at(keys, 0), "field1", 11)
+    Conn.hset(Enum.at(keys, 1), "field2", 99)
+    Conn.hset(Enum.at(keys, 3), "field1", 44)
+    {hits, new_from} = Getter.get(@prefix, "field1", from, to, rollup)
 
     assert length(hits) == 2
     assert_time new_from, "2017-03-22T01:45:00Z"
@@ -77,22 +77,22 @@ defmodule Castle.RedisIntervalCacheGetterTest do
   end
 
   test "hits all 0s", %{from: from, to: to, rollup: rollup, keys: keys} do
-    Conn.hset(Enum.at(keys, 0), "key2", 99)
-    Conn.hset(Enum.at(keys, 1), "key2", 99)
-    Conn.hset(Enum.at(keys, 2), "key2", 99)
-    Conn.hset(Enum.at(keys, 3), "key2", 99)
-    {hits, new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+    Conn.hset(Enum.at(keys, 0), "field2", 99)
+    Conn.hset(Enum.at(keys, 1), "field2", 99)
+    Conn.hset(Enum.at(keys, 2), "field2", 99)
+    Conn.hset(Enum.at(keys, 3), "field2", 99)
+    {hits, new_from} = Getter.get(@prefix, "field1", from, to, rollup)
     assert length(hits) == 4
     assert new_from == nil
   end
 
   test "assumes 0 on misses within a few seconds of now", %{from: from, to: to, rollup: rollup, keys: keys} do
-    Conn.hset(Enum.at(keys, 0), "key1", 11)
-    Conn.hset(Enum.at(keys, 1), "key1", 22)
-    Conn.hset(Enum.at(keys, 2), "key1", 33)
+    Conn.hset(Enum.at(keys, 0), "field1", 11)
+    Conn.hset(Enum.at(keys, 1), "field1", 22)
+    Conn.hset(Enum.at(keys, 2), "field1", 33)
     hits_at_time = fn(time) ->
       with_mock Timex, [:passthrough], [now: fn() -> get_dtim(time) end] do
-        {hits, _new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+        {hits, _new_from} = Getter.get(@prefix, "field1", from, to, rollup)
         {length(hits), List.last(hits).count}
       end
     end

--- a/test/redis/interval_cache/getter_test.exs
+++ b/test/redis/interval_cache/getter_test.exs
@@ -1,0 +1,105 @@
+defmodule Castle.RedisIntervalCacheGetterTest do
+  use Castle.RedisCase, async: false
+  use Castle.TimeHelpers
+
+  @moduletag :redis
+
+  import Mock
+  alias Castle.Redis.Conn, as: Conn
+  alias Castle.Redis.Interval.Keys, as: Keys
+  alias Castle.Redis.Interval.Getter, as: Getter
+
+  @prefix "interval.cache.getter.test"
+
+  setup do
+    redis_clear("#{@prefix}*")
+    from = get_dtim("2017-03-22T01:15:00Z")
+    to = get_dtim("2017-03-22T02:15:00Z")
+    rollup = BigQuery.TimestampRollups.QuarterHourly
+    keys = Keys.keys(@prefix, rollup.range(from, to, false))
+    [from: from, to: to, rollup: rollup, keys: keys]
+  end
+
+  test "hits the entire range", %{from: from, to: to, rollup: rollup, keys: keys} do
+    Conn.hset(Enum.at(keys, 0), "key1", 11)
+    Conn.hset(Enum.at(keys, 1), "key1", 22)
+    Conn.hset(Enum.at(keys, 2), "key1", 33)
+    Conn.hset(Enum.at(keys, 3), "key1", 44)
+    {hits, new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+
+    assert length(hits) == 4
+    assert new_from == nil
+    assert_time Enum.at(hits, 0).time, "2017-03-22T01:15:00Z"
+    assert_time Enum.at(hits, 1).time, "2017-03-22T01:30:00Z"
+    assert_time Enum.at(hits, 2).time, "2017-03-22T01:45:00Z"
+    assert_time Enum.at(hits, 3).time, "2017-03-22T02:00:00Z"
+    assert Enum.at(hits, 0).count == 11
+    assert Enum.at(hits, 1).count == 22
+    assert Enum.at(hits, 2).count == 33
+    assert Enum.at(hits, 3).count == 44
+  end
+
+  test "misses a partial range", %{from: from, to: to, rollup: rollup, keys: keys} do
+    Conn.hset(Enum.at(keys, 0), "key1", 11)
+    Conn.hset(Enum.at(keys, 1), "key1", 22)
+    Conn.hset(Enum.at(keys, 3), "key1", 44)
+    {hits, new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+
+    assert length(hits) == 2
+    assert_time new_from, "2017-03-22T01:45:00Z"
+    assert_time Enum.at(hits, 0).time, "2017-03-22T01:15:00Z"
+    assert_time Enum.at(hits, 1).time, "2017-03-22T01:30:00Z"
+    assert Enum.at(hits, 0).count == 11
+    assert Enum.at(hits, 1).count == 22
+  end
+
+  test "misses the entire range", %{from: from, to: to, rollup: rollup, keys: keys} do
+    Conn.hset(Enum.at(keys, 1), "key1", 22)
+    Conn.hset(Enum.at(keys, 2), "key1", 33)
+    Conn.hset(Enum.at(keys, 3), "key1", 44)
+    {hits, new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+    assert hits == []
+    assert_time new_from, "2017-03-22T01:15:00Z"
+  end
+
+  test "interprets hash-field misses as 0", %{from: from, to: to, rollup: rollup, keys: keys} do
+    Conn.hset(Enum.at(keys, 0), "key1", 11)
+    Conn.hset(Enum.at(keys, 1), "key2", 99)
+    Conn.hset(Enum.at(keys, 3), "key1", 44)
+    {hits, new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+
+    assert length(hits) == 2
+    assert_time new_from, "2017-03-22T01:45:00Z"
+    assert_time Enum.at(hits, 0).time, "2017-03-22T01:15:00Z"
+    assert_time Enum.at(hits, 1).time, "2017-03-22T01:30:00Z"
+    assert Enum.at(hits, 0).count == 11
+    assert Enum.at(hits, 1).count == 0
+  end
+
+  test "hits all 0s", %{from: from, to: to, rollup: rollup, keys: keys} do
+    Conn.hset(Enum.at(keys, 0), "key2", 99)
+    Conn.hset(Enum.at(keys, 1), "key2", 99)
+    Conn.hset(Enum.at(keys, 2), "key2", 99)
+    Conn.hset(Enum.at(keys, 3), "key2", 99)
+    {hits, new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+    assert length(hits) == 4
+    assert new_from == nil
+  end
+
+  test "assumes 0 on misses within a few seconds of now", %{from: from, to: to, rollup: rollup, keys: keys} do
+    Conn.hset(Enum.at(keys, 0), "key1", 11)
+    Conn.hset(Enum.at(keys, 1), "key1", 22)
+    Conn.hset(Enum.at(keys, 2), "key1", 33)
+    hits_at_time = fn(time) ->
+      with_mock Timex, [:passthrough], [now: fn() -> get_dtim(time) end] do
+        {hits, _new_from} = Getter.get(@prefix, "key1", from, to, rollup)
+        {length(hits), List.last(hits).count}
+      end
+    end
+    assert hits_at_time.("2017-03-22T03:00:00Z") == {3, 33}
+    assert hits_at_time.("2017-03-22T02:00:00Z") == {4, 0}
+    assert hits_at_time.("2017-03-22T02:00:29Z") == {4, 0}
+    assert hits_at_time.("2017-03-22T02:00:31Z") == {3, 33}
+    assert hits_at_time.("2017-03-22T01:00:00Z") == {4, 0}
+  end
+end

--- a/test/redis/interval_cache/keys_test.exs
+++ b/test/redis/interval_cache/keys_test.exs
@@ -1,0 +1,33 @@
+defmodule Castle.RedisIntervalCacheKeysTest do
+  use Castle.RedisCase, async: true
+  use Castle.TimeHelpers
+
+  @moduletag :redis
+
+  alias Castle.Redis.Interval.Keys, as: Keys
+
+  test "returns keys for a range" do
+    times = [
+      get_dtim("2017-03-22T01:15:00Z"),
+      get_dtim("2017-03-22T01:30:00Z"),
+      get_dtim("2017-03-22T01:45:00Z"),
+      get_dtim("2017-03-22T02:00:00Z"),
+      get_dtim("2017-03-22T02:15:00Z")
+    ]
+    assert Keys.keys("foo.bar", times) == [
+      "foo.bar.2017-03-22T01:15:00Z",
+      "foo.bar.2017-03-22T01:30:00Z",
+      "foo.bar.2017-03-22T01:45:00Z",
+      "foo.bar.2017-03-22T02:00:00Z",
+      "foo.bar.2017-03-22T02:15:00Z"
+    ]
+  end
+
+  test "returns keys for empty range" do
+    assert Keys.keys("foo.bar", []) == []
+  end
+
+  test "returns a single key" do
+    assert Keys.key("foo.bar", get_dtim("2017-03-22T01:45:00Z")) == "foo.bar.2017-03-22T01:45:00Z"
+  end
+end

--- a/test/redis/interval_cache/setter_test.exs
+++ b/test/redis/interval_cache/setter_test.exs
@@ -1,0 +1,52 @@
+defmodule Castle.RedisIntervalCacheSetterTest do
+  use Castle.RedisCase, async: false
+  use Castle.TimeHelpers
+
+  @moduletag :redis
+
+  import Mock
+  alias Castle.Redis.Conn, as: Conn
+  alias Castle.Redis.Interval.Keys, as: Keys
+  alias Castle.Redis.Interval.Setter, as: Setter
+
+  @prefix "interval.cache.setter.test"
+
+  setup do
+    redis_clear("#{@prefix}*")
+    from = get_dtim("2017-03-22T01:15:00Z")
+    to = get_dtim("2017-03-22T02:15:00Z")
+    [from: from, to: to]
+  end
+
+  test "sets ttl according to the time" do
+    with_mock Timex, [:passthrough], [now: fn() -> get_dtim("2017-03-22T01:15:00Z") end] do
+      assert Setter.interval_ttl(get_dtim("2017-03-22T00:15:00Z")) == 0
+      assert Setter.interval_ttl(get_dtim("2017-03-22T00:16:00Z")) == 300
+      assert Setter.interval_ttl(get_dtim("2017-03-22T01:14:00Z")) == 300
+      assert Setter.interval_ttl(get_dtim("2017-03-22T01:15:00Z")) == 300
+      assert Setter.interval_ttl(get_dtim("2017-03-22T02:20:00Z")) == 300
+    end
+  end
+
+  test "sets empty counts", %{from: from, to: to} do
+    assert redis_count("#{@prefix}*") == 0
+    Setter.set(@prefix, from, to, %{})
+    assert redis_count("#{@prefix}*") == 1
+    assert Conn.command(["TTL", List.first(redis_keys("#{@prefix}*"))]) == -1
+  end
+
+  test "sets a ttl on the key close to now", %{from: from, to: to} do
+    with_mock Timex, [:passthrough], [now: fn() -> get_dtim("2017-03-22T01:15:00Z") end] do
+      Setter.set(@prefix, from, to, %{})
+      assert Conn.command(["TTL", List.first(redis_keys("#{@prefix}*"))]) == 300
+    end
+  end
+
+  test "sets values", %{from: from, to: to} do
+    Setter.set(@prefix, from, to, %{1 => 123, "foo" => "bar"})
+    assert Conn.hget(Keys.key(@prefix, from), 1) == 123
+    assert Conn.hget(Keys.key(@prefix, from), "foo") == "bar"
+    assert Conn.hget(Keys.key(@prefix, to), 1) == nil
+    assert redis_count("#{@prefix}*") == 1
+  end
+end

--- a/test/redis/interval_cache_test.exs
+++ b/test/redis/interval_cache_test.exs
@@ -1,192 +1,92 @@
 defmodule Castle.RedisIntervalCacheTest do
   use Castle.RedisCase, async: true
+  use Castle.TimeHelpers
 
   @moduletag :redis
 
-  import Mock
   import Castle.Redis.IntervalCache
-  alias BigQuery.TimestampRollups.{Daily, Hourly, Monthly, QuarterHourly, Weekly}
+  alias Castle.Redis.Conn, as: Conn
+  alias Castle.Redis.Interval.Keys, as: Keys
+  alias BigQuery.TimestampRollups.QuarterHourly, as: QuarterHourly
 
   @prefix "interval.cache.test"
 
   setup do
     redis_clear("#{@prefix}*")
-    [
-      from:       get_dtim("2017-03-22T01:15:00Z"),
-      partial_to: get_dtim("2017-03-22T02:00:00Z"),
-      to:         get_dtim("2017-03-22T02:45:00Z"),
-    ]
+    from = get_dtim("2017-03-22T01:15:00Z")
+    to = get_dtim("2017-03-22T02:15:00Z")
+    intv = %BigQuery.Interval{from: from, to: to, rollup: QuarterHourly}
+    keys = Keys.keys("#{@prefix}.#{intv.rollup.name()}", intv.rollup.range(from, to, false))
+    [interval: intv, keys: keys]
   end
 
-  test "assembles keys for timestamps", %{from: from, to: to} do
-    keys = interval_keys(@prefix, from, to, QuarterHourly)
-    assert length(keys) == 6
-    assert hd(keys) == "#{@prefix}.15MIN.2017-03-22T01:15:00Z"
-    assert List.last(keys) == "#{@prefix}.15MIN.2017-03-22T02:30:00Z"
-  end
-
-  test_with_mock "sets a separate ttl for current intervals", Timex, [:passthrough], [
-    now: fn() -> get_dtim("2017-10-23T11:55:00Z") end
-  ] do
-    past  = get_dtim("2017-10-23T09:55:00Z")
-    now   = get_dtim("2017-10-23T11:55:00Z")
-    later = get_dtim("2017-10-23T12:10:01Z")
-
-    assert interval_ttls(past, now, QuarterHourly) == [2592000, 2592000, 2592000, 2592000, 300, 300, 300, 300, 300]
-    assert interval_ttls(past, now, Hourly) == [2592000, 300, 300]
-    assert interval_ttls(past, now, Daily) == [300]
-    assert interval_ttls(past, now, Weekly) == [300]
-    assert interval_ttls(past, now, Monthly) == [300]
-
-    assert interval_ttls(past, later, QuarterHourly) == [2592000, 2592000, 2592000, 2592000, 300, 300, 300, 300, 300, 300]
-    assert interval_ttls(past, later, Hourly) == [2592000, 300, 300, 300]
-    assert interval_ttls(past, later, Daily) == [300]
-  end
-
-  test "gets an entire time interval", %{from: from, to: to} do
-    Castle.Redis.Conn.set(%{
-      "#{@prefix}.15MIN.2017-03-22T01:15:00Z" => 10,
-      "#{@prefix}.15MIN.2017-03-22T01:30:00Z" => 9,
-      "#{@prefix}.15MIN.2017-03-22T01:45:00Z" => 8,
-      "#{@prefix}.15MIN.2017-03-22T02:00:00Z" => 7,
-      "#{@prefix}.15MIN.2017-03-22T02:15:00Z" => 6,
-      "#{@prefix}.15MIN.2017-03-22T02:30:00Z" => 5,
-    })
-    {hits, new_from} = interval_get(@prefix, from, to, QuarterHourly)
-
-    assert length(hits) == 6
-    assert hd(hits).count == 10
-    assert format_dtim(hd(hits).time) == "2017-03-22T01:15:00Z"
-    assert format_dtim(List.last(hits).time) == "2017-03-22T02:30:00Z"
-    assert is_nil(new_from)
-  end
-
-  test "gets a partial time interval", %{from: from, to: to} do
-    Castle.Redis.Conn.set(%{
-      "#{@prefix}.15MIN.2017-03-22T01:15:00Z" => 10,
-      "#{@prefix}.15MIN.2017-03-22T01:30:00Z" => 9,
-      "#{@prefix}.15MIN.2017-03-22T02:00:00Z" => 7,
-      "#{@prefix}.15MIN.2017-03-22T02:15:00Z" => 6,
-    })
-    {hits, new_from} = interval_get(@prefix, from, to, QuarterHourly)
-
-    assert length(hits) == 2
-    assert hd(hits).count == 10
-    assert List.last(hits).count == 9
-    refute is_nil(new_from)
-    assert format_dtim(new_from) == "2017-03-22T01:45:00Z"
-  end
-
-  test "misses the whole time interval", %{from: from, to: to} do
-    Castle.Redis.Conn.set(%{
-      "#{@prefix}.15MIN.2017-03-22T01:30:00Z" => 9,
-      "#{@prefix}.15MIN.2017-03-22T01:45:00Z" => 8,
-    })
-    {hits, new_from} = interval_get(@prefix, from, to, QuarterHourly)
-
-    assert length(hits) == 0
-    refute is_nil(new_from)
-    assert format_dtim(new_from) == "2017-03-22T01:15:00Z"
-  end
-
-  test "sets the time interval", %{from: from, partial_to: partial_to} do
-    interval_set(@prefix, from, partial_to, QuarterHourly, [55, 66, 77])
-
-    assert redis_count("#{@prefix}*") == 3
-    assert Enum.member? redis_keys("#{@prefix}*"), "#{@prefix}.15MIN.2017-03-22T01:15:00Z"
-    assert Enum.member? redis_keys("#{@prefix}*"), "#{@prefix}.15MIN.2017-03-22T01:30:00Z"
-    assert Enum.member? redis_keys("#{@prefix}*"), "#{@prefix}.15MIN.2017-03-22T01:45:00Z"
-  end
-
-  test "handles blank responses", %{from: from, to: to} do
-    {data, meta} = interval @prefix, from, to, QuarterHourly, fn(new_from) ->
-      assert format_dtim(new_from) == "2017-03-22T01:15:00Z"
-      {[], %{meta: "data"}}
-    end
-    assert redis_count("#{@prefix}*") == 6
-    assert Enum.uniq(Enum.map(data, &(&1.count))) == [0]
-    assert meta.meta == "data"
+  test "misses the whole interval", %{interval: intv} do
+    {data, meta} = interval(@prefix, intv, "foobar", &test_work_fn/1)
+    assert redis_count("#{@prefix}*") == 4
     assert meta.cache_hits == 0
+    assert length(data) == 4
+    assert_time data, 0, "2017-03-22T01:15:00Z"
+    assert_time data, 1, "2017-03-22T01:30:00Z"
+    assert_time data, 2, "2017-03-22T01:45:00Z"
+    assert_time data, 3, "2017-03-22T02:00:00Z"
+    assert Enum.at(data, 0).count == 13
+    assert Enum.at(data, 1).count == 0
+    assert Enum.at(data, 2).count == 0
+    assert Enum.at(data, 3).count == 43
+
+    {data2, meta2} = interval(@prefix, intv, "foobar", &test_work_fn/1)
+    assert redis_count("#{@prefix}*") == 4
+    assert meta2.cache_hits == 4
+    assert meta2.cached == true
+    assert data2 == data
   end
 
-  test "caches response intervals", %{from: from, partial_to: partial_to, to: to} do
-    data1 = [
-      %{count: 55, time: get_dtim("2017-03-22T01:15:00Z")},
-      %{count: 66, time: get_dtim("2017-03-22T01:30:00Z")},
-      %{count: 77, time: get_dtim("2017-03-22T01:45:00Z")},
-    ]
-    data2 = [
-      %{count: 88, time: get_dtim("2017-03-22T02:00:00Z")},
-      %{count: 99, time: get_dtim("2017-03-22T02:15:00Z")},
-      %{count: 111, time: get_dtim("2017-03-22T02:30:00Z")},
-    ]
+  test "partially hits the cache", %{interval: intv, keys: keys} do
+    Conn.hset(Enum.at(keys, 0), "foobar", 11)
+    Conn.hset(Enum.at(keys, 1), "foobar", 22)
+    Conn.hset(Enum.at(keys, 3), "foobar", 44)
+    {data, meta} = interval(@prefix, intv, "foobar", &test_work_fn/1)
+    assert redis_count("#{@prefix}*") == 4
+    assert meta.cache_hits == 2
+    assert length(data) == 4
+    assert_time data, 0, "2017-03-22T01:15:00Z"
+    assert_time data, 1, "2017-03-22T01:30:00Z"
+    assert_time data, 2, "2017-03-22T01:45:00Z"
+    assert_time data, 3, "2017-03-22T02:00:00Z"
+    assert Enum.at(data, 0).count == 11
+    assert Enum.at(data, 1).count == 22
+    assert Enum.at(data, 2).count == 0
+    assert Enum.at(data, 3).count == 43
+  end
 
-    {data, meta} = interval @prefix, from, partial_to, QuarterHourly, fn(new_from) ->
-      assert format_dtim(new_from) == "2017-03-22T01:15:00Z"
-      {data1, %{meta: "data"}}
-    end
-    assert redis_count("#{@prefix}*") == 3
-    assert Enum.map(data, &(&1.count)) == [55, 66, 77]
-    assert format_dtim(hd(data).time) == "2017-03-22T01:15:00Z"
-    assert meta.meta == "data"
-    assert meta.cache_hits == 0
-
-    {data, meta} = interval @prefix, from, to, QuarterHourly, fn(new_from) ->
-      assert format_dtim(new_from) == "2017-03-22T02:00:00Z"
-      {data2, %{meta: "stuff"}}
-    end
-    assert redis_count("#{@prefix}*") == 6
-    assert Enum.map(data, &(&1.count)) == [55, 66, 77, 88, 99, 111]
-    assert format_dtim(hd(data).time) == "2017-03-22T01:15:00Z"
-    assert meta.meta == "stuff"
+  test "hits cache 0s", %{interval: intv, keys: keys} do
+    Conn.hset(Enum.at(keys, 0), "nothing", 99)
+    Conn.hset(Enum.at(keys, 1), "foobar", 22)
+    Conn.hset(Enum.at(keys, 2), "nothing", 99)
+    {data, meta} = interval(@prefix, intv, "foobar", &test_work_fn/1)
+    assert redis_count("#{@prefix}*") == 4
     assert meta.cache_hits == 3
+    assert length(data) == 4
+    assert_time data, 0, "2017-03-22T01:15:00Z"
+    assert_time data, 1, "2017-03-22T01:30:00Z"
+    assert_time data, 2, "2017-03-22T01:45:00Z"
+    assert_time data, 3, "2017-03-22T02:00:00Z"
+    assert Enum.at(data, 0).count == 0
+    assert Enum.at(data, 1).count == 22
+    assert Enum.at(data, 2).count == 0
+    assert Enum.at(data, 3).count == 43
+  end
 
-    {data, meta} = interval @prefix, from, to, QuarterHourly, fn(_new_from) ->
-      raise "should not have called this"
+  defp test_work_fn(intv) do
+    lookup = %{
+      "2017-03-22T01:15:00Z" => %{1 => 11, 2 => 12, "foobar" => 13},
+      "2017-03-22T01:30:00Z" => %{1 => 21, 2 => 22},
+      "2017-03-22T01:45:00Z" => %{},
+      "2017-03-22T02:00:00Z" => %{"foobar" => 43},
+    }
+    data = Enum.map intv.rollup.range(intv.from, intv.to, false), fn(dtim) ->
+      {dtim, Map.get(lookup, format_dtim(dtim))}
     end
-    assert Enum.map(data, &(&1.count)) == [55, 66, 77, 88, 99, 111]
-    assert format_dtim(hd(data).time) == "2017-03-22T01:15:00Z"
-    assert meta.cached == true
-    assert meta.cache_hits == 6
-  end
-
-  test "fills zeros into results", %{from: from, to: to} do
-    result = [
-      %{count: 11, time: get_dtim("2017-03-22T01:45:00Z")},
-      %{count: 22, time: get_dtim("2017-03-22T02:15:00Z")},
-    ]
-    {data, _} = interval_fill_zeros({result, %{}}, from, to, QuarterHourly)
-    assert Enum.map(data, &(&1.time)) == QuarterHourly.range(from, to, false)
-    assert Enum.map(data, &(&1.count)) == [0, 0, 11, 0, 22, 0]
-  end
-
-  test "caches empty response intervals", %{from: from, partial_to: partial_to, to: to} do
-    data1 = [
-      %{count: 66, time: get_dtim("2017-03-22T01:30:00Z")},
-    ]
-    data2 = [
-      %{count: 88, time: get_dtim("2017-03-22T02:00:00Z")},
-      %{count: 111, time: get_dtim("2017-03-22T02:30:00Z")},
-    ]
-
-    {data, _} = interval @prefix, from, partial_to, QuarterHourly, fn(_) -> {data1, %{}} end
-    assert redis_count("#{@prefix}*") == 3
-    assert Enum.map(data, &(&1.count)) == [0, 66, 0]
-    assert format_dtim(hd(data).time) == "2017-03-22T01:15:00Z"
-
-    {data, _} = interval @prefix, from, to, QuarterHourly, fn(_) -> {data2, %{}} end
-    assert redis_count("#{@prefix}*") == 6
-    assert Enum.map(data, &(&1.count)) == [0, 66, 0, 88, 0, 111]
-    assert format_dtim(hd(data).time) == "2017-03-22T01:15:00Z"
-  end
-
-  def get_dtim(dtim_str) do
-    {:ok, dtim, _} = DateTime.from_iso8601(dtim_str)
-    dtim
-  end
-
-  def format_dtim(dtim) do
-    {:ok, formatted} = Timex.format(dtim, "{ISO:Extended:Z}")
-    formatted
+    {data, %{meta: "data"}}
   end
 end

--- a/test/support/big_query_case.ex
+++ b/test/support/big_query_case.ex
@@ -9,16 +9,6 @@ defmodule Castle.BigQueryCase do
         %{from: start, to: finish, rollup: rollup}
       end
 
-      defp assert_time(result, index, expected_str) do
-        assert_time(Enum.at(result, index).time, expected_str)
-      end
-      defp assert_time(time, expected_str) do
-        {:ok, expected, _} = DateTime.from_iso8601(expected_str)
-        {:ok, format_expected} = Timex.format(expected, "{ISO:Extended:Z}")
-        {:ok, format_time} = Timex.format(time, "{ISO:Extended:Z}")
-        assert format_time == format_expected
-      end
-
       defp mutate_dtim(dtim_str, mutate_fn) do
         {:ok, dtim, _} = DateTime.from_iso8601(dtim_str)
         {:ok, formatted} = Timex.format(mutate_fn.(dtim), "{ISO:Extended:Z}")

--- a/test/support/big_query_case.ex
+++ b/test/support/big_query_case.ex
@@ -10,10 +10,13 @@ defmodule Castle.BigQueryCase do
       end
 
       defp assert_time(result, index, expected_str) do
+        assert_time(Enum.at(result, index).time, expected_str)
+      end
+      defp assert_time(time, expected_str) do
         {:ok, expected, _} = DateTime.from_iso8601(expected_str)
         {:ok, format_expected} = Timex.format(expected, "{ISO:Extended:Z}")
-        {:ok, format_result} = Timex.format(Enum.at(result, index).time, "{ISO:Extended:Z}")
-        assert format_result == format_expected
+        {:ok, format_time} = Timex.format(time, "{ISO:Extended:Z}")
+        assert format_time == format_expected
       end
 
       defp mutate_dtim(dtim_str, mutate_fn) do

--- a/test/support/fake_redis.ex
+++ b/test/support/fake_redis.ex
@@ -2,8 +2,11 @@ defmodule Castle.FakeRedis do
   @behaviour Castle.Redis
 
   def cached(_key, _ttl, work_fn), do: work_fn.()
-  def interval(_key_prefix, from, _to, _interval, work_fn), do: work_fn.(from)
-  def interval(_key_prefix, intv, work_fn), do: work_fn.(intv)
+
+  def interval(_key_prefix, intv, ident, work_fn) do
+    {data, meta} = work_fn.(intv)
+    {Castle.Redis.IntervalCache.filter_work(data, ident), meta}
+  end
 
   # TODO: these aren't as easy
   def partition(_key_prefix, _worker_fns), do: {[], %{fake: true}}

--- a/test/support/time_helpers.ex
+++ b/test/support/time_helpers.ex
@@ -1,0 +1,25 @@
+defmodule Castle.TimeHelpers do
+  defmacro __using__(_opts) do
+    quote do
+      defp get_dtim(dtim_str) do
+        case DateTime.from_iso8601(dtim_str) do
+          {:ok, dtim, _} -> dtim
+          _ -> nil
+        end
+      end
+
+      defp format_dtim(dtim) do
+        case Timex.format(dtim, "{ISO:Extended:Z}") do
+          {:ok, formatted} -> formatted
+          _ -> "ERROR - BAD DATE"
+        end
+      end
+
+      defp assert_time(list, idx, exp), do: assert_time(Enum.at(list, idx), exp)
+      defp assert_time(%{time: time}, expected_str), do: assert_time(time, expected_str)
+      defp assert_time(time, expected_str) do
+        assert format_dtim(time) == expected_str
+      end
+    end
+  end
+end

--- a/web/controllers/api/download_controller.ex
+++ b/web/controllers/api/download_controller.ex
@@ -18,8 +18,8 @@ defmodule Castle.API.DownloadController do
   end
 
   def index(%{assigns: %{interval: intv}} = conn, %{"podcast_id" => id}) do
-    {data, meta} = @redis.interval key("podcast.#{id}"), intv, fn(new_intv) ->
-      @bigquery.podcast_downloads(id, new_intv)
+    {data, meta} = @redis.interval "downloads.podcasts", intv, id, fn(new_intv) ->
+      @bigquery.podcast_downloads(new_intv)
     end
     render conn, IntervalView, "podcast.json", id: id, interval: intv.rollup.name,
       downloads: data, meta: meta
@@ -34,14 +34,13 @@ defmodule Castle.API.DownloadController do
   end
 
   def index(%{assigns: %{interval: intv}} = conn, %{"episode_guid" => guid}) do
-    {data, meta} = @redis.interval key("episode.#{guid}"), intv, fn(new_intv) ->
-      @bigquery.episode_downloads(guid, new_intv)
+    {data, meta} = @redis.interval "downloads.episodes", intv, guid, fn(new_intv) ->
+      @bigquery.episode_downloads(new_intv)
     end
     render conn, IntervalView, "episode.json", guid: guid, interval: intv.rollup.name,
       downloads: data, meta: meta
   end
 
-  defp key(id), do: "downloads.#{id}"
   defp key(id, intv, group) do
     "downloads.#{id}.#{key_interval(intv)}.group.#{group.name}.#{group.limit}"
   end

--- a/web/controllers/api/impression_controller.ex
+++ b/web/controllers/api/impression_controller.ex
@@ -18,8 +18,8 @@ defmodule Castle.API.ImpressionController do
   end
 
   def index(%{assigns: %{interval: intv}} = conn, %{"podcast_id" => id}) do
-    {data, meta} = @redis.interval key("podcast.#{id}"), intv, fn(new_intv) ->
-      @bigquery.podcast_impressions(id, new_intv)
+    {data, meta} = @redis.interval "impressions.podcasts", intv, id, fn(new_intv) ->
+      @bigquery.podcast_impressions(new_intv)
     end
     render conn, IntervalView, "podcast.json", id: id, interval: intv.rollup.name,
       impressions: data, meta: meta
@@ -34,14 +34,13 @@ defmodule Castle.API.ImpressionController do
   end
 
   def index(%{assigns: %{interval: intv}} = conn, %{"episode_guid" => guid}) do
-    {data, meta} = @redis.interval key("episode.#{guid}"), intv, fn(new_intv) ->
-      @bigquery.episode_impressions(guid, new_intv)
+    {data, meta} = @redis.interval "impressions.episodes", intv, guid, fn(new_intv) ->
+      @bigquery.episode_impressions(new_intv)
     end
     render conn, IntervalView, "episode.json", guid: guid, interval: intv.rollup.name,
       impressions: data, meta: meta
   end
 
-  defp key(id), do: "impressions.#{id}"
   defp key(id, intv, group) do
     "impressions.#{id}.#{key_interval(intv)}.group.#{group.name}.#{group.limit}"
   end


### PR DESCRIPTION
🚧 WIP :crazy-idea:

This allows setting downloads/impressions cache keys in such a way that they:

1. Can always be fetched on-demand by Castle, in reasonable time, with the in-progress intervals expiring in 5 minutes
2. Can be INCR'd by an external lambda in a way to prevent Castle from recalculating them
3. Can be (eventually, not in this PR) recalculated by a Castle worker, at the top of every hour, to true-up the numbers

## Redis Caching

Previously, our cache keys looked something like:

```
downloads.podcast.70.HOUR.2017-10-19T08:00:00Z = 14841
downloads.podcast.70.HOUR.2017-10-19T09:00:00Z = 14832
downloads.episode.94b247a3-3d7c-4a07-97aa-95f87c539093.15MIN.2017-10-18T21:15:00 = 18505
```

Which for one, results in just a ton of cache keys.  Plus it makes it more difficult to redis-INCR them from an external lambda.  If an episode gets 0 downloads in a 15 minute interval ... the key never gets set, so it's a cache-miss, and Castle will go ask BigQuery for that interval (and get the 0 back).

This PR flips all cache keys into redis hashes:

```
downloads.podcasts.HOUR.2017-10-19T08:00:00Z = {70: 14841}
downloads.podcasts.HOUR.2017-10-19T09:00:00Z = {70: 14832}
downloads.episodes.15MIN.2017-10-18T21:15:00 = {94b247a3-3d7c-4a07-97aa-95f87c539093: 18505}
```

And castle is smart enough to know that _if a cache key exists_, any id not found in that hash means "0 downloads".  So with the above examples ... Castle would get a cache-hit (0) for podcast-id 99 at 9:00.  But it would get a cache-miss for podcast-id 99 at 10:00, and go ask BigQuery for that interval.

## Big Querying

Additionally, instead of asking BigQuery for a single podcast/episode, it will now ask for _all_ existing podcasts/episodes in that timeframe.  In theory, this is the exact same work/billing for BigQuery - since has a columnar structure, you're processing the same amount of data to get 1-episode vs 100-episodes.  But it does seem to take a bit longer to send that data over the wire, especially with episodes.  (Feeder is at about 3K episodes at the moment, fwiw).

## TODOs

In prod, we'll eventually have a lambda doing:

```
HINCRBY downloads.podcasts.HOUR.2017-10-19T08:00:00Z 70 1
EXPIRE downloads.podcasts.HOUR.2017-10-19T08:00:00Z 300
```

Probably tune that EXPIRE to happen at 15-minutes after the next hour.  Then 10-minutes after the hour, we'll run the Castle-worker to go through all keys about to expire, and actually calculate those values from BigQuery.

Thus: Castle download queries should never hit BigQuery.  And if they do, it's not a big deal.

Phew.
