### PR TITLE
Paging and optimize grouping

### DIFF
--- a/lib/big_query/base/http.ex
+++ b/lib/big_query/base/http.ex
@@ -12,7 +12,13 @@ defmodule BigQuery.Base.HTTP do
         raise error
     end
   end
+  def get(params, "" <> path), do: get(path, params)
+  def get(path, params) do
+    encoded = params |> Map.put("timeoutMs", @timeout) |> URI.encode_query()
+    get("#{path}?#{encoded}")
+  end
 
+  def post(body, "" <> path), do: post(path, body)
   def post(path, body) do
     case get_token() do
       {:ok, token} ->

--- a/lib/big_query/base/query_result.ex
+++ b/lib/big_query/base/query_result.ex
@@ -51,6 +51,15 @@ defmodule BigQuery.Base.QueryResult do
           else: String.to_integer(value)
         {:ok, dtim} = DateTime.from_unix(num)
         dtim
+      {"RECORD", %{"v" => v}} -> parse_value(v, "RECORD")
+      {"RECORD", %{"f" => f}} -> parse_value(f, "RECORD")
+      {"RECORD", _} when is_list(value) ->
+        Enum.map(value, &(parse_value(&1, "RECORD")))
+      {"RECORD", _} ->
+        case Integer.parse(value) do
+           {i, ""} -> i
+           _ -> value
+        end
     end
   end
 

--- a/test/big_query/base/query_result_test.exs
+++ b/test/big_query/base/query_result_test.exs
@@ -83,6 +83,31 @@ defmodule Castle.BigQueryBaseQueryResultTest do
     assert hd(result).stamp == nil
   end
 
+  test "handles nested int/string records" do
+    {result, _meta} = from_response(%{
+      "rows" => [
+        %{"f" => [
+          %{"v" => [
+            %{"v" => %{"f" => [%{"v" => "foo"}, %{"v" => "176"}]}},
+            %{"v" => %{"f" => [%{"v" => "bar"}, %{"v" => "5873"}]}}
+          ]}
+        ]},
+        %{"f" => [
+          %{"v" => [
+            %{"v" => %{"f" => [%{"v" => "64"}, %{"v" => "309.3"}]}},
+            %{"v" => %{"f" => [%{"v" => "59a"}, %{"v" => "stuff"}]}}
+          ]}
+        ]},
+      ],
+      "schema" => %{"fields" => [%{"name" => "rec", "type" => "RECORD"}]}
+    })
+
+    assert is_list result
+    assert length(result) == 2
+    assert Enum.at(result, 0).rec == [["foo", 176], ["bar", 5873]]
+    assert Enum.at(result, 1).rec == [[64, "309.3"], ["59a", "stuff"]]
+  end
+
   test "parses metadata" do
     {_result, meta} = from_response(%{
       "rows" => [],

--- a/test/big_query/base/query_test.exs
+++ b/test/big_query/base/query_test.exs
@@ -8,6 +8,7 @@ defmodule Castle.BigQueryBaseQueryTest do
     {result, meta} = query("""
       SELECT * FROM #{Env.get(:bq_impressions_table)}
       WHERE is_duplicate = true
+      AND _PARTITIONTIME = TIMESTAMP("2017-10-29")
       LIMIT 2
     """)
 
@@ -26,6 +27,7 @@ defmodule Castle.BigQueryBaseQueryTest do
     {result, meta} = query(%{is_dup: true, lim: 2}, """
       SELECT * FROM #{Env.get(:bq_impressions_table)}
       WHERE is_duplicate = @is_dup
+      AND _PARTITIONTIME = TIMESTAMP("2017-10-29")
       LIMIT @lim
     """)
 
@@ -37,5 +39,21 @@ defmodule Castle.BigQueryBaseQueryTest do
     assert meta.bytes >= 0
     assert meta.megabytes >= 0
     assert meta.total == 2
+  end
+
+  @tag :external
+  test "loads all pages of results" do
+    {result, meta} = query(%{is_dup: true, lim: 215}, """
+      SELECT * FROM #{Env.get(:bq_impressions_table)}
+      WHERE is_duplicate = @is_dup
+      AND _PARTITIONTIME = TIMESTAMP("2017-10-29")
+      LIMIT @lim
+    """, 100)
+
+    assert is_list result
+    assert length(result) == 215
+    assert meta.bytes >= 0
+    assert meta.megabytes >= 0
+    assert meta.total == 215
   end
 end


### PR DESCRIPTION
Okay, so maybe this is more of a fix than a feat.

- [x] Always page through BQ results, in case we hit the 10MB-per-page limit
  - The POST to [Jobs: query](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/query) sometimes returns a `pageToken`
  - Use this to GET the next page from [Jobs: getQueryResults](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/getQueryResults)
- [x] Bottleneck when attempting to group results by timestamp ... make BQ do the grouping through structs/arrays.  Who knew that elixir would be slow at something?
  - Old results (flat):
    ```
    2017-09-01T00:00:00Z, 123, 66
    2017-09-01T00:00:00Z, 456, 77
    2017-09-01T00:00:00Z, 789, 88
    2017-09-01T01:00:00Z, 123, 99
    ```
  - New results (array of structs of podcast-ids/counts):
    ```
    2017-09-01T00:00:00Z, [{123, 66}, {456, 77}, {789, 88}]
    2017-09-01T01:00:00Z, [{123, 99}]
    ```