### PR TITLE
Fix interval ranges

### DIFF
--- a/lib/big_query/base/timestamp.ex
+++ b/lib/big_query/base/timestamp.ex
@@ -29,11 +29,13 @@ defmodule BigQuery.Base.Timestamp do
   end
 
   def timestamp_params(interval) do
+    lower = interval.rollup.floor(interval.from)
+    upper = interval.rollup.next(interval.to)
     %{
-      from_dtim: interval.from,
-      to_dtim: interval.to,
-      pstart: Timex.beginning_of_day(interval.from),
-      pend: Timex.end_of_day(interval.to),
+      from_dtim: lower,
+      to_dtim: upper,
+      pstart: Timex.beginning_of_day(lower),
+      pend: Timex.end_of_day(upper),
     }
   end
 
@@ -42,8 +44,7 @@ defmodule BigQuery.Base.Timestamp do
   end
 
   def group({data, meta}, intv) do
-    data = intv.rollup.range(intv.from, intv.to, false)
-           |> insert_counts(data)
+    data = intv.rollup.range(intv.from, intv.to) |> insert_counts(data)
     {data, meta}
   end
 

--- a/lib/big_query/timestamp_rollup.ex
+++ b/lib/big_query/timestamp_rollup.ex
@@ -4,6 +4,7 @@ defmodule BigQuery.TimestampRollup do
   @callback is_a?(String.t) :: boolean
   @callback floor(%DateTime{}) :: %DateTime{}
   @callback ceiling(%DateTime{}) :: %DateTime{}
-  @callback range(%DateTime{}, %DateTime{}, boolean) :: [%DateTime{}]
+  @callback next(%DateTime{}) :: %DateTime{}
+  @callback range(%DateTime{}, %DateTime{}) :: [%DateTime{}]
   @callback count_range(%DateTime{}, %DateTime{}) :: pos_integer()
 end

--- a/lib/big_query/timestamp_rollups/daily.ex
+++ b/lib/big_query/timestamp_rollups/daily.ex
@@ -19,24 +19,24 @@ defmodule BigQuery.TimestampRollups.Daily do
     end
   end
 
-  def range(from, to, _inclusive_to=false) do
-    range(floor(from), ceiling(to), [])
+  def next(time) do
+    Timex.shift(time, seconds: 1) |> ceiling()
   end
-  def range(from, to, _inclusive_to=true) do
-    range(floor(from), ceiling(Timex.shift(to, seconds: 1)), [])
+
+  def range(from, to) do
+    range(floor(from), floor(to), [])
   end
   def range(from, to, acc) do
-    if Timex.compare(from, to) >= 0 do
+    if Timex.compare(from, to) > 0 do
       acc
     else
-      next_from = Timex.shift(from, seconds: 1) |> ceiling()
-      range(next_from, to, acc ++ [from])
+      next(from) |> range(to, acc ++ [from])
     end
   end
 
   def count_range(from, to) do
     start = floor(from) |> Timex.to_unix()
-    stop = ceiling(to) |> Timex.to_unix()
+    stop = next(to) |> Timex.to_unix()
     Float.ceil(max(stop - start, 0) / 86400) |> round
   end
 end

--- a/lib/big_query/timestamp_rollups/hourly.ex
+++ b/lib/big_query/timestamp_rollups/hourly.ex
@@ -17,11 +17,12 @@ defmodule BigQuery.TimestampRollups.Hourly do
     Timex.from_unix(round(Float.ceil(seconds / 3600) * 3600))
   end
 
-  def range(from, to, _inclusive_to=false) do
-    range(floor(from), ceiling(to), [])
+  def next(time) do
+    Timex.shift(time, seconds: 1) |> ceiling()
   end
-  def range(from, to, _inclusive_to=true) do
-    range(floor(from), ceiling(Timex.shift(to, seconds: 1)), [])
+
+  def range(from, to) do
+    range(floor(from), next(to), [])
   end
   def range(from, to, acc) do
     if Timex.compare(from, to) >= 0 do
@@ -34,7 +35,7 @@ defmodule BigQuery.TimestampRollups.Hourly do
 
   def count_range(from, to) do
     start = floor(from) |> Timex.to_unix()
-    stop = ceiling(to) |> Timex.to_unix()
+    stop = next(to) |> Timex.to_unix()
     Float.ceil(max(stop - start, 0) / 3600) |> round
   end
 end

--- a/lib/big_query/timestamp_rollups/monthly.ex
+++ b/lib/big_query/timestamp_rollups/monthly.ex
@@ -19,11 +19,12 @@ defmodule BigQuery.TimestampRollups.Monthly do
     end
   end
 
-  def range(from, to, _inclusive_to=false) do
-    range(floor(from), ceiling(to), [])
+  def next(time) do
+    Timex.shift(time, seconds: 1) |> ceiling()
   end
-  def range(from, to, _inclusive_to=true) do
-    range(floor(from), ceiling(Timex.shift(to, seconds: 1)), [])
+
+  def range(from, to) do
+    range(floor(from), next(to), [])
   end
   def range(from, to, acc) do
     if Timex.compare(from, to) >= 0 do
@@ -37,7 +38,7 @@ defmodule BigQuery.TimestampRollups.Monthly do
   # this is an estimate, since days-per-month varies
   def count_range(from, to) do
     start = floor(from) |> Timex.to_unix()
-    stop = ceiling(to) |> Timex.to_unix()
+    stop = next(to) |> Timex.to_unix()
     Float.ceil(max(stop - start, 0) / 2592000) |> round
   end
 end

--- a/lib/big_query/timestamp_rollups/quarter_hourly.ex
+++ b/lib/big_query/timestamp_rollups/quarter_hourly.ex
@@ -19,11 +19,12 @@ defmodule BigQuery.TimestampRollups.QuarterHourly do
     Timex.from_unix(round(Float.ceil(seconds / 900) * 900))
   end
 
-  def range(from, to, _inclusive_to=false) do
-    range(floor(from), ceiling(to), [])
+  def next(time) do
+    Timex.shift(time, seconds: 1) |> ceiling()
   end
-  def range(from, to, _inclusive_to=true) do
-    range(floor(from), ceiling(Timex.shift(to, seconds: 1)), [])
+
+  def range(from, to) do
+    range(floor(from), next(to), [])
   end
   def range(from, to, acc) do
     if Timex.compare(from, to) >= 0 do
@@ -36,7 +37,7 @@ defmodule BigQuery.TimestampRollups.QuarterHourly do
 
   def count_range(from, to) do
     start = floor(from) |> Timex.to_unix()
-    stop = ceiling(to) |> Timex.to_unix()
+    stop = next(to) |> Timex.to_unix()
     Float.ceil(max(stop - start, 0) / 900) |> round
   end
 end

--- a/lib/big_query/timestamp_rollups/weekly.ex
+++ b/lib/big_query/timestamp_rollups/weekly.ex
@@ -19,11 +19,12 @@ defmodule BigQuery.TimestampRollups.Weekly do
     end
   end
 
-  def range(from, to, _inclusive_to=false) do
-    range(floor(from), ceiling(to), [])
+  def next(time) do
+    Timex.shift(time, seconds: 1) |> ceiling()
   end
-  def range(from, to, _inclusive_to=true) do
-    range(floor(from), ceiling(Timex.shift(to, seconds: 1)), [])
+
+  def range(from, to) do
+    range(floor(from), next(to), [])
   end
   def range(from, to, acc) do
     if Timex.compare(from, to) >= 0 do
@@ -36,7 +37,7 @@ defmodule BigQuery.TimestampRollups.Weekly do
 
   def count_range(from, to) do
     start = floor(from) |> Timex.to_unix()
-    stop = ceiling(to) |> Timex.to_unix()
+    stop = next(to) |> Timex.to_unix()
     Float.ceil(max(stop - start, 0) / 604800) |> round
   end
 end

--- a/lib/plugs/interval_plug.ex
+++ b/lib/plugs/interval_plug.ex
@@ -26,7 +26,7 @@ defmodule Castle.Plugs.Interval do
   defp round_time_window(%{status: nil, assigns: %{interval: intv}} = conn) do
     assign(conn, :interval, %{
       from: intv.rollup.floor(intv.from),
-      to: intv.rollup.ceiling(intv.to),
+      to: intv.rollup.floor(intv.to),
       rollup: intv.rollup,
     })
   end

--- a/lib/redis/interval/getter.ex
+++ b/lib/redis/interval/getter.ex
@@ -5,7 +5,7 @@ defmodule Castle.Redis.Interval.Getter do
   @buffer_seconds 30
 
   def get(key_prefix, ident, from, to, rollup) do
-    range = rollup.range(from, to, false)
+    range = rollup.range(from, to)
     counts = Keys.keys(key_prefix, range) |> Conn.hget(ident)
     cache_hits(range, counts)
   end

--- a/lib/redis/interval_cache.ex
+++ b/lib/redis/interval_cache.ex
@@ -21,8 +21,7 @@ defmodule Castle.Redis.IntervalCache do
 
     # bulk set all the %{ident => counts}
     Enum.each(data, fn({time, ids_to_counts}) ->
-      next_time = intv.rollup.ceiling(Timex.shift(time, seconds: 1))
-      Setter.set(key_prefix, time, next_time, ids_to_counts)
+      Setter.set(key_prefix, time, intv.rollup.next(time), ids_to_counts)
     end)
 
     # filter down to the specific ident we want to return

--- a/test/big_query/base/timestamp_test.exs
+++ b/test/big_query/base/timestamp_test.exs
@@ -30,15 +30,15 @@ defmodule Castle.BigQueryBaseTimestampTest do
     interval = %BigQuery.Interval{from: start, to: finish, rollup: BigQuery.TimestampRollups.QuarterHourly}
     params = timestamp_params(interval)
 
-    assert_time params.from_dtim, "2017-03-22T21:54:52Z"
-    assert_time params.to_dtim, "2017-03-28T04:12:00Z"
+    assert_time params.from_dtim, "2017-03-22T21:45:00Z"
+    assert_time params.to_dtim, "2017-03-28T04:15:00Z"
     assert_time params.pstart, "2017-03-22T00:00:00Z"
     assert_time params.pend, "2017-03-28T23:59:59.999999Z"
   end
 
   test "groups results" do
     start = get_dtim("2017-03-28T04:00:00Z")
-    finish = get_dtim("2017-03-28T11:00:00Z")
+    finish = get_dtim("2017-03-28T10:00:00Z")
     interval = %BigQuery.Interval{from: start, to: finish, rollup: BigQuery.TimestampRollups.Hourly}
     raw = [
       %{time: get_dtim("2017-03-28T05:00:00Z"), counts: [[123, 11]]},

--- a/test/big_query/downloads_test.exs
+++ b/test/big_query/downloads_test.exs
@@ -7,7 +7,7 @@ defmodule Castle.BigQueryDownloadsTest do
   import BigQuery.Downloads
 
   test "lists downloads for all podcasts" do
-    intv = interval("2017-06-27T21:45:00Z", "2017-06-28T04:15:00Z", BigQuery.TimestampRollups.QuarterHourly)
+    intv = interval("2017-06-27T21:45:00Z", "2017-06-28T04:00:00Z", BigQuery.TimestampRollups.QuarterHourly)
     {result, _meta} = for_podcasts(intv)
 
     assert is_list result
@@ -21,7 +21,7 @@ defmodule Castle.BigQueryDownloadsTest do
   end
 
   test "groups downloads for a podcast" do
-    intv = interval("2017-07-10T21:45:00Z", "2017-07-11T04:15:00Z", BigQuery.TimestampRollups.QuarterHourly)
+    intv = interval("2017-07-10T21:45:00Z", "2017-07-11T04:00:00Z", BigQuery.TimestampRollups.QuarterHourly)
     group = Castle.Plugs.Group.get("city", 3)
     {result, _meta} = group_podcast(57, intv, group)
 
@@ -33,6 +33,7 @@ defmodule Castle.BigQueryDownloadsTest do
     assert_time result, 2, "2017-07-10T21:45:00Z"
     assert_time result, 3, "2017-07-10T21:45:00Z"
     assert_time result, 4, "2017-07-10T22:00:00Z"
+    assert_time result, 26 * 4 - 1, "2017-07-11T04:00:00Z"
 
     assert Enum.at(result, 0).display == nil
     assert Enum.at(result, 1).display != nil
@@ -45,7 +46,7 @@ defmodule Castle.BigQueryDownloadsTest do
   end
 
   test "lists downloads for all episodes" do
-    intv = interval("2017-06-27T21:45:00Z", "2017-06-28T04:15:00Z", BigQuery.TimestampRollups.QuarterHourly)
+    intv = interval("2017-06-27T21:45:00Z", "2017-06-28T04:00:00Z", BigQuery.TimestampRollups.QuarterHourly)
     {result, _meta} = for_episodes(intv)
 
     assert is_list result
@@ -61,7 +62,7 @@ defmodule Castle.BigQueryDownloadsTest do
   end
 
   test "groups downloads for an episode" do
-    intv = interval("2017-07-10T21:45:00Z", "2017-07-11T04:15:00Z", BigQuery.TimestampRollups.QuarterHourly)
+    intv = interval("2017-07-10T21:45:00Z", "2017-07-11T04:00:00Z", BigQuery.TimestampRollups.QuarterHourly)
     group = Castle.Plugs.Group.get("country", 2)
     {result, _meta} = group_episode("7acf74b8-7b0a-4e9e-90be-f69052064b77", intv, group)
 

--- a/test/big_query/impressions_test.exs
+++ b/test/big_query/impressions_test.exs
@@ -54,7 +54,7 @@ defmodule Castle.BigQueryImpressionsTest do
     assert_time time, "2017-06-27T21:00:00Z"
     assert length(Map.keys(counts)) > 10
     assert Map.has_key?(counts, "7acf74b8-7b0a-4e9e-90be-f69052064b77")
-    assert Map.get(counts, "7acf74b8-7b0a-4e9e-90be-f69052064b77") == 1056
+    assert Map.get(counts, "7acf74b8-7b0a-4e9e-90be-f69052064b77") == 4184
   end
 
   test "groups impressions for an episode" do

--- a/test/big_query/impressions_test.exs
+++ b/test/big_query/impressions_test.exs
@@ -7,7 +7,7 @@ defmodule Castle.BigQueryImpressionsTest do
   import BigQuery.Impressions
 
   test "lists impressions for all podcasts" do
-    intv = interval("2017-06-27T21:45:00Z", "2017-06-28T04:15:00Z", BigQuery.TimestampRollups.QuarterHourly)
+    intv = interval("2017-06-27T21:45:00Z", "2017-06-28T04:00:00Z", BigQuery.TimestampRollups.QuarterHourly)
     {result, _meta} = for_podcasts(intv)
 
     assert is_list result
@@ -21,7 +21,7 @@ defmodule Castle.BigQueryImpressionsTest do
   end
 
   test "groups impressions for a podcast" do
-    intv = interval("2017-07-10T21:45:00Z", "2017-07-11T04:15:00Z", BigQuery.TimestampRollups.QuarterHourly)
+    intv = interval("2017-07-10T21:45:00Z", "2017-07-11T04:00:00Z", BigQuery.TimestampRollups.QuarterHourly)
     group = Castle.Plugs.Group.get("city", 3)
     {result, _meta} = group_podcast(57, intv, group)
     assert is_list result
@@ -44,7 +44,7 @@ defmodule Castle.BigQueryImpressionsTest do
   end
 
   test "lists impressions for all episodes" do
-    intv = interval("2017-06-27T21:45:00Z", "2017-06-28T04:15:00Z", BigQuery.TimestampRollups.Hourly)
+    intv = interval("2017-06-27T21:45:00Z", "2017-06-28T04:00:00Z", BigQuery.TimestampRollups.Hourly)
     {result, _meta} = for_episodes(intv)
 
     assert is_list result
@@ -58,7 +58,7 @@ defmodule Castle.BigQueryImpressionsTest do
   end
 
   test "groups impressions for an episode" do
-    intv = interval("2017-07-10T04:00:00Z", "2017-07-10T22:00:00Z", BigQuery.TimestampRollups.Hourly)
+    intv = interval("2017-07-10T04:00:00Z", "2017-07-10T21:00:00Z", BigQuery.TimestampRollups.Hourly)
     group = Castle.Plugs.Group.get("country", 2)
     {result, _meta} = group_episode("7acf74b8-7b0a-4e9e-90be-f69052064b77", intv, group)
     assert is_list result

--- a/test/big_query/timestamp_rollups/daily_test.exs
+++ b/test/big_query/timestamp_rollups/daily_test.exs
@@ -5,7 +5,8 @@ defmodule Castle.BigQueryTimestampRollupsDailyTest do
 
   defp format_floor(str), do: mutate_dtim(str, &floor/1)
   defp format_ceiling(str), do: mutate_dtim(str, &ceiling/1)
-  defp format_range(s1, s2, ex), do: mutate_dtims(s1, s2, ex, &range/3)
+  defp format_next(str), do: mutate_dtim(str, &next/1)
+  defp format_range(s1, s2), do: mutate_dtims(s1, s2, &range/2)
   defp get_count(s1, s2), do: call_dtims(s1, s2, &count_range/2)
 
   test "has basic data" do
@@ -29,21 +30,21 @@ defmodule Castle.BigQueryTimestampRollupsDailyTest do
     assert format_ceiling("2017-03-31T23:59:59Z") == "2017-04-01T00:00:00Z"
   end
 
-  test "exclusive range" do
-    range = format_range("2017-03-22T01:15:00Z", "2017-03-25T12:00:00Z", false)
+  test "next" do
+    assert format_next("2017-03-22T01:15:00Z") == "2017-03-23T00:00:00Z"
+    assert format_next("2017-03-01T00:00:00Z") == "2017-03-02T00:00:00Z"
+    assert format_next("2017-03-31T23:59:59Z") == "2017-04-01T00:00:00Z"
+  end
+
+  test "range" do
+    range = format_range("2017-03-22T01:15:00Z", "2017-03-25T12:00:00Z")
     assert length(range) == 4
     assert Enum.at(range, 0) == "2017-03-22T00:00:00Z"
     assert Enum.at(range, 1) == "2017-03-23T00:00:00Z"
     assert Enum.at(range, 2) == "2017-03-24T00:00:00Z"
     assert Enum.at(range, 3) == "2017-03-25T00:00:00Z"
 
-    range = format_range("2017-03-22T00:00:00Z", "2017-03-23T00:00:00Z", false)
-    assert length(range) == 1
-    assert Enum.at(range, 0) == "2017-03-22T00:00:00Z"
-  end
-
-  test "inclusive range" do
-    range = format_range("2017-03-22T00:00:00Z", "2017-03-23T00:00:00Z", true)
+    range = format_range("2017-03-22T00:00:00Z", "2017-03-23T00:00:00Z")
     assert length(range) == 2
     assert Enum.at(range, 0) == "2017-03-22T00:00:00Z"
     assert Enum.at(range, 1) == "2017-03-23T00:00:00Z"
@@ -51,7 +52,8 @@ defmodule Castle.BigQueryTimestampRollupsDailyTest do
 
   test "count range" do
     assert get_count("2017-03-22T01:15:00Z", "2017-03-25T12:00:00Z") == 4
-    assert get_count("2017-03-22T01:15:00Z", "2017-03-25T00:00:00Z") == 3
+    assert get_count("2017-03-22T01:15:00Z", "2017-03-25T00:00:00Z") == 4
     assert get_count("2017-03-22T01:15:00Z", "2017-03-25T00:00:01Z") == 4
+    assert get_count("2017-03-22T01:15:00Z", "2017-03-26T00:00:00Z") == 5
   end
 end

--- a/test/big_query/timestamp_rollups/hourly_test.exs
+++ b/test/big_query/timestamp_rollups/hourly_test.exs
@@ -5,7 +5,8 @@ defmodule Castle.BigQueryTimestampRollupsHourlyTest do
 
   defp format_floor(str), do: mutate_dtim(str, &floor/1)
   defp format_ceiling(str), do: mutate_dtim(str, &ceiling/1)
-  defp format_range(s1, s2, ex), do: mutate_dtims(s1, s2, ex, &range/3)
+  defp format_next(str), do: mutate_dtim(str, &next/1)
+  defp format_range(s1, s2), do: mutate_dtims(s1, s2, &range/2)
   defp get_count(s1, s2), do: call_dtims(s1, s2, &count_range/2)
 
   test "has basic data" do
@@ -29,31 +30,29 @@ defmodule Castle.BigQueryTimestampRollupsHourlyTest do
     assert format_ceiling("2017-03-31T23:59:59Z") == "2017-04-01T00:00:00Z"
   end
 
-  test "exclusive range" do
-    range = format_range("2017-03-22T23:15:00Z", "2017-03-23T02:00:00Z", false)
-    assert length(range) == 3
-    assert Enum.at(range, 0) == "2017-03-22T23:00:00Z"
-    assert Enum.at(range, 1) == "2017-03-23T00:00:00Z"
-    assert Enum.at(range, 2) == "2017-03-23T01:00:00Z"
-
-    range = format_range("2017-03-22T23:00:00Z", "2017-03-23T00:59:59Z", false)
-    assert length(range) == 2
-    assert Enum.at(range, 0) == "2017-03-22T23:00:00Z"
-    assert Enum.at(range, 1) == "2017-03-23T00:00:00Z"
+  test "next" do
+    assert format_next("2017-03-22T01:15:00Z") == "2017-03-22T02:00:00Z"
+    assert format_next("2017-03-01T00:00:00Z") == "2017-03-01T01:00:00Z"
+    assert format_next("2017-03-31T23:59:59Z") == "2017-04-01T00:00:00Z"
   end
 
-  test "inclusive range" do
-    range = format_range("2017-03-22T23:15:00Z", "2017-03-23T02:00:00Z", true)
+  test "range" do
+    range = format_range("2017-03-22T23:15:00Z", "2017-03-23T02:00:00Z")
     assert length(range) == 4
     assert Enum.at(range, 0) == "2017-03-22T23:00:00Z"
     assert Enum.at(range, 1) == "2017-03-23T00:00:00Z"
     assert Enum.at(range, 2) == "2017-03-23T01:00:00Z"
     assert Enum.at(range, 3) == "2017-03-23T02:00:00Z"
+
+    range = format_range("2017-03-22T23:00:00Z", "2017-03-23T00:59:59Z")
+    assert length(range) == 2
+    assert Enum.at(range, 0) == "2017-03-22T23:00:00Z"
+    assert Enum.at(range, 1) == "2017-03-23T00:00:00Z"
   end
 
   test "count range" do
-    assert get_count("2017-03-22T23:15:00Z", "2017-03-23T02:00:00Z") == 3
-    assert get_count("2017-03-22T23:00:00Z", "2017-03-23T02:00:01Z") == 4
-    assert get_count("2017-03-22T23:15:00Z", "2017-03-24T02:00:00Z") == 27
+    assert get_count("2017-03-22T23:15:00Z", "2017-03-23T01:59:59Z") == 3
+    assert get_count("2017-03-22T23:00:00Z", "2017-03-23T02:00:00Z") == 4
+    assert get_count("2017-03-22T23:15:00Z", "2017-03-24T02:00:00Z") == 28
   end
 end

--- a/test/big_query/timestamp_rollups/monthly_test.exs
+++ b/test/big_query/timestamp_rollups/monthly_test.exs
@@ -5,7 +5,8 @@ defmodule Castle.BigQueryTimestampRollupsMonthlyTest do
 
   defp format_floor(str), do: mutate_dtim(str, &floor/1)
   defp format_ceiling(str), do: mutate_dtim(str, &ceiling/1)
-  defp format_range(s1, s2, ex), do: mutate_dtims(s1, s2, ex, &range/3)
+  defp format_next(str), do: mutate_dtim(str, &next/1)
+  defp format_range(s1, s2), do: mutate_dtims(s1, s2, &range/2)
   defp get_count(s1, s2), do: call_dtims(s1, s2, &count_range/2)
 
   test "has basic data" do
@@ -29,21 +30,20 @@ defmodule Castle.BigQueryTimestampRollupsMonthlyTest do
     assert format_ceiling("2017-04-01T00:00:01Z") == "2017-05-01T00:00:00Z"
   end
 
-  test "exclusive range" do
-    range = format_range("2017-03-22T01:15:00Z", "2017-05-01T12:00:00Z", false)
+  test "next" do
+    assert format_next("2017-03-22T01:15:00Z") == "2017-04-01T00:00:00Z"
+    assert format_next("2017-03-01T00:00:00Z") == "2017-04-01T00:00:00Z"
+    assert format_next("2017-04-01T00:00:01Z") == "2017-05-01T00:00:00Z"
+  end
+
+  test "range" do
+    range = format_range("2017-03-22T01:15:00Z", "2017-05-01T12:00:00Z")
     assert length(range) == 3
     assert Enum.at(range, 0) == "2017-03-01T00:00:00Z"
     assert Enum.at(range, 1) == "2017-04-01T00:00:00Z"
     assert Enum.at(range, 2) == "2017-05-01T00:00:00Z"
 
-    range = format_range("2017-03-01T00:00:00Z", "2017-05-01T00:00:00Z", false)
-    assert length(range) == 2
-    assert Enum.at(range, 0) == "2017-03-01T00:00:00Z"
-    assert Enum.at(range, 1) == "2017-04-01T00:00:00Z"
-  end
-
-  test "inclusive range" do
-    range = format_range("2017-03-01T00:00:00Z", "2017-05-01T00:00:00Z", true)
+    range = format_range("2017-03-01T00:00:00Z", "2017-05-01T00:00:00Z")
     assert length(range) == 3
     assert Enum.at(range, 0) == "2017-03-01T00:00:00Z"
     assert Enum.at(range, 1) == "2017-04-01T00:00:00Z"
@@ -53,6 +53,6 @@ defmodule Castle.BigQueryTimestampRollupsMonthlyTest do
   test "count range" do
     # these are estimates for monthly ... and usually on the high side
     assert get_count("2017-06-01T01:15:00Z", "2017-08-10T12:00:00Z") == 4
-    assert get_count("2017-06-01T00:00:00Z", "2017-09-01T00:00:00Z") == 4
+    assert get_count("2017-06-01T00:00:00Z", "2017-09-01T00:00:00Z") == 5
   end
 end

--- a/test/big_query/timestamp_rollups/quarter_hourly_test.exs
+++ b/test/big_query/timestamp_rollups/quarter_hourly_test.exs
@@ -5,7 +5,8 @@ defmodule Castle.BigQueryTimestampRollupsQuarterHourlyTest do
 
   defp format_floor(str), do: mutate_dtim(str, &floor/1)
   defp format_ceiling(str), do: mutate_dtim(str, &ceiling/1)
-  defp format_range(s1, s2, ex), do: mutate_dtims(s1, s2, ex, &range/3)
+  defp format_next(str), do: mutate_dtim(str, &next/1)
+  defp format_range(s1, s2), do: mutate_dtims(s1, s2, &range/2)
   defp get_count(s1, s2), do: call_dtims(s1, s2, &count_range/2)
 
   test "has basic data" do
@@ -29,15 +30,22 @@ defmodule Castle.BigQueryTimestampRollupsQuarterHourlyTest do
     assert format_ceiling("2017-03-31T23:59:59Z") == "2017-04-01T00:00:00Z"
   end
 
-  test "exclusive range" do
-    range = format_range("2017-03-22T01:14:00Z", "2017-03-22T02:00:00Z", false)
-    assert length(range) == 4
+  test "next" do
+    assert format_next("2017-03-22T01:14:00Z") == "2017-03-22T01:15:00Z"
+    assert format_next("2017-03-22T01:15:00Z") == "2017-03-22T01:30:00Z"
+    assert format_next("2017-03-31T23:59:59Z") == "2017-04-01T00:00:00Z"
+  end
+
+  test "range" do
+    range = format_range("2017-03-22T01:14:00Z", "2017-03-22T02:00:00Z")
+    assert length(range) == 5
     assert Enum.at(range, 0) == "2017-03-22T01:00:00Z"
     assert Enum.at(range, 1) == "2017-03-22T01:15:00Z"
     assert Enum.at(range, 2) == "2017-03-22T01:30:00Z"
     assert Enum.at(range, 3) == "2017-03-22T01:45:00Z"
+    assert Enum.at(range, 4) == "2017-03-22T02:00:00Z"
 
-    range = format_range("2017-03-22T01:15:00Z", "2017-03-22T02:00:01Z", false)
+    range = format_range("2017-03-22T01:15:00Z", "2017-03-22T02:00:01Z")
     assert length(range) == 4
     assert Enum.at(range, 0) == "2017-03-22T01:15:00Z"
     assert Enum.at(range, 1) == "2017-03-22T01:30:00Z"
@@ -45,19 +53,9 @@ defmodule Castle.BigQueryTimestampRollupsQuarterHourlyTest do
     assert Enum.at(range, 3) == "2017-03-22T02:00:00Z"
   end
 
-  test "inclusive range" do
-    range = format_range("2017-03-22T01:14:00Z", "2017-03-22T02:00:00Z", true)
-    assert length(range) == 5
-    assert Enum.at(range, 0) == "2017-03-22T01:00:00Z"
-    assert Enum.at(range, 1) == "2017-03-22T01:15:00Z"
-    assert Enum.at(range, 2) == "2017-03-22T01:30:00Z"
-    assert Enum.at(range, 3) == "2017-03-22T01:45:00Z"
-    assert Enum.at(range, 4) == "2017-03-22T02:00:00Z"
-  end
-
   test "count range" do
     assert get_count("2017-03-22T01:15:00Z", "2017-03-22T02:00:01Z") == 4
     assert get_count("2017-03-22T01:14:00Z", "2017-03-22T02:00:01Z") == 5
-    assert get_count("2017-03-22T01:14:59Z", "2017-03-22T02:00:00Z") == 4
+    assert get_count("2017-03-22T01:14:59Z", "2017-03-22T02:00:00Z") == 5
   end
 end

--- a/test/big_query/timestamp_rollups/weekly_test.exs
+++ b/test/big_query/timestamp_rollups/weekly_test.exs
@@ -5,7 +5,8 @@ defmodule Castle.BigQueryTimestampRollupsWeeklyTest do
 
   defp format_floor(str), do: mutate_dtim(str, &floor/1)
   defp format_ceiling(str), do: mutate_dtim(str, &ceiling/1)
-  defp format_range(s1, s2, ex), do: mutate_dtims(s1, s2, ex, &range/3)
+  defp format_next(str), do: mutate_dtim(str, &next/1)
+  defp format_range(s1, s2), do: mutate_dtims(s1, s2, &range/2)
   defp get_count(s1, s2), do: call_dtims(s1, s2, &count_range/2)
 
   test "has basic data" do
@@ -29,21 +30,19 @@ defmodule Castle.BigQueryTimestampRollupsWeeklyTest do
     assert format_ceiling("2017-03-18T23:59:59Z") == "2017-03-19T00:00:00Z"
   end
 
-  test "exclusive range" do
-    range = format_range("2017-03-13T01:15:00Z", "2017-03-28T12:00:00Z", false)
+  test "next" do
+    assert format_next("2017-03-22T01:15:00Z") == "2017-03-26T00:00:00Z"
+    assert format_next("2017-03-19T00:00:00Z") == "2017-03-26T00:00:00Z"
+    assert format_next("2017-03-18T23:59:59Z") == "2017-03-19T00:00:00Z"
+  end
+
+  test "range" do
+    range = format_range("2017-03-13T01:15:00Z", "2017-03-28T12:00:00Z")
     assert length(range) == 3
     assert Enum.at(range, 0) == "2017-03-12T00:00:00Z"
     assert Enum.at(range, 1) == "2017-03-19T00:00:00Z"
     assert Enum.at(range, 2) == "2017-03-26T00:00:00Z"
 
-    range = format_range("2017-03-12T00:00:00Z", "2017-03-26T00:00:00Z", false)
-    assert length(range) == 2
-    assert Enum.at(range, 0) == "2017-03-12T00:00:00Z"
-    assert Enum.at(range, 1) == "2017-03-19T00:00:00Z"
-  end
-
-  test "inclusive range" do
-    range = format_range("2017-03-12T00:00:00Z", "2017-03-26T00:00:00Z", true)
     assert length(range) == 3
     assert Enum.at(range, 0) == "2017-03-12T00:00:00Z"
     assert Enum.at(range, 1) == "2017-03-19T00:00:00Z"
@@ -52,7 +51,7 @@ defmodule Castle.BigQueryTimestampRollupsWeeklyTest do
 
   test "count range" do
     assert get_count("2017-03-13T01:15:00Z", "2017-03-28T12:00:00Z") == 3
-    assert get_count("2017-03-13T01:15:00Z", "2017-03-26T00:00:00Z") == 2
+    assert get_count("2017-03-13T01:15:00Z", "2017-03-26T00:00:00Z") == 3
     assert get_count("2017-03-13T01:15:00Z", "2017-04-21T12:00:00Z") == 6
   end
 end

--- a/test/plugs/interval_plug_test.exs
+++ b/test/plugs/interval_plug_test.exs
@@ -8,7 +8,7 @@ defmodule Castle.PlugsIntervalTest do
   test "parses intervals", %{conn: conn} do
     intv = get_interval(conn, @from, @to, @interval)
     assert Timex.to_unix(intv.from) == 1491055200
-    assert Timex.to_unix(intv.to) == 1491056100
+    assert Timex.to_unix(intv.to) == 1491055200
     assert intv.rollup.name == "15MIN"
   end
 
@@ -43,14 +43,14 @@ defmodule Castle.PlugsIntervalTest do
     assert get_lower(conn, "1M", "2017-04-04T23:22:44Z") == "2017-04-01T00:00:00+00:00"
   end
 
-  test "rounds the upper time window up", %{conn: conn} do
+  test "rounds the upper time window down", %{conn: conn} do
     assert get_upper(conn, "15m", "2017-04-01T23:45:00Z") == "2017-04-01T23:45:00+00:00"
-    assert get_upper(conn, "15m", "2017-04-01T23:45:01Z") == "2017-04-02T00:00:00+00:00"
-    assert get_upper(conn, "1h", "2017-04-01T00:59:59Z") == "2017-04-01T01:00:00+00:00"
+    assert get_upper(conn, "15m", "2017-04-01T23:45:01Z") == "2017-04-01T23:45:00+00:00"
+    assert get_upper(conn, "1h", "2017-04-01T00:59:59Z") == "2017-04-01T00:00:00+00:00"
     assert get_upper(conn, "1h", "2017-04-01T23:00:00Z") == "2017-04-01T23:00:00+00:00"
-    assert get_upper(conn, "1d", "2017-04-01T12:12:12Z") == "2017-04-02T00:00:00+00:00"
-    assert get_upper(conn, "1w", "2017-04-02T12:12:12Z") == "2017-04-09T00:00:00+00:00"
-    assert get_upper(conn, "1M", "2017-04-02T12:12:12Z") == "2017-05-01T00:00:00+00:00"
+    assert get_upper(conn, "1d", "2017-04-01T12:12:12Z") == "2017-04-01T00:00:00+00:00"
+    assert get_upper(conn, "1w", "2017-04-02T12:12:12Z") == "2017-04-02T00:00:00+00:00"
+    assert get_upper(conn, "1M", "2017-04-02T12:12:12Z") == "2017-04-01T00:00:00+00:00"
   end
 
   defp get_lower(conn, interval, from) do

--- a/test/redis/interval_cache/getter_test.exs
+++ b/test/redis/interval_cache/getter_test.exs
@@ -14,9 +14,9 @@ defmodule Castle.RedisIntervalCacheGetterTest do
   setup do
     redis_clear("#{@prefix}*")
     from = get_dtim("2017-03-22T01:15:00Z")
-    to = get_dtim("2017-03-22T02:15:00Z")
+    to = get_dtim("2017-03-22T02:00:00Z")
     rollup = BigQuery.TimestampRollups.QuarterHourly
-    keys = Keys.keys(@prefix, rollup.range(from, to, false))
+    keys = Keys.keys(@prefix, rollup.range(from, to))
     [from: from, to: to, rollup: rollup, keys: keys]
   end
 

--- a/test/redis/interval_cache_test.exs
+++ b/test/redis/interval_cache_test.exs
@@ -14,9 +14,9 @@ defmodule Castle.RedisIntervalCacheTest do
   setup do
     redis_clear("#{@prefix}*")
     from = get_dtim("2017-03-22T01:15:00Z")
-    to = get_dtim("2017-03-22T02:15:00Z")
+    to = get_dtim("2017-03-22T02:00:00Z")
     intv = %BigQuery.Interval{from: from, to: to, rollup: QuarterHourly}
-    keys = Keys.keys("#{@prefix}.#{intv.rollup.name()}", intv.rollup.range(from, to, false))
+    keys = Keys.keys("#{@prefix}.#{intv.rollup.name()}", intv.rollup.range(from, to))
     [interval: intv, keys: keys]
   end
 
@@ -84,7 +84,7 @@ defmodule Castle.RedisIntervalCacheTest do
       "2017-03-22T01:45:00Z" => %{},
       "2017-03-22T02:00:00Z" => %{"foobar" => 43},
     }
-    data = Enum.map intv.rollup.range(intv.from, intv.to, false), fn(dtim) ->
+    data = Enum.map intv.rollup.range(intv.from, intv.to), fn(dtim) ->
       {dtim, Map.get(lookup, format_dtim(dtim))}
     end
     {data, %{meta: "data"}}

--- a/test/support/big_query_case.ex
+++ b/test/support/big_query_case.ex
@@ -15,10 +15,10 @@ defmodule Castle.BigQueryCase do
         formatted
       end
 
-      defp mutate_dtims(dtim_str1, dtim_str2, param, mutate_fn) do
+      defp mutate_dtims(dtim_str1, dtim_str2, mutate_fn) do
         {:ok, dtim1, _} = DateTime.from_iso8601(dtim_str1)
         {:ok, dtim2, _} = DateTime.from_iso8601(dtim_str2)
-        mutate_fn.(dtim1, dtim2, param) |> Enum.map(fn(dtim) ->
+        mutate_fn.(dtim1, dtim2) |> Enum.map(fn(dtim) ->
           {:ok, formatted} = Timex.format(dtim, "{ISO:Extended:Z}")
           formatted
         end)


### PR DESCRIPTION
I was still doing interval ranges wrong.  Here's what it does now (easiest to explain by example):

```
# ?from=2017-07-15&to=2017-07-17&interval=1d
-> returns 3 rows 
-> queries for timestamp >= 2017-07-15T00:00:00 AND timestamp < 2017-07-18T00:00:00

# ?from=2017-07-15T06:58:00&to=2017-07-17T23:59:59&interval=1d
-> returns 3 rows
-> interval plug floor()s both dates ... so it ends up being the same as the first example

# ?from=2017-07-15T06:58:00&to=2017-07-18T00:00:00&interval=1d
-> returns 4 rows 
-> queries for timestamp >= 2017-07-15T00:00:00 AND timestamp < 2017-07-19T00:00:00
```