### PR TITLE
First bucket time offset

### DIFF
--- a/lib/castle_web/controllers/api/bucket_helper.ex
+++ b/lib/castle_web/controllers/api/bucket_helper.ex
@@ -3,11 +3,16 @@ defmodule CastleWeb.API.BucketHelper do
   # put the data counts into their respective timestamp buckets
   # (assumes both data and buckets are sorted timestamp-ASC)
   def bucketize(result, %{from: from, to: to, bucket: bucket}) do
-    bucketize(result, bucket.range(from, to))
+    range = adjust_range(from, bucket.range(from, to))
+    bucketize(result, range)
   end
   def bucketize({data, meta}, buckets) when is_list(buckets) do
     {combine_data(buckets, data), meta}
   end
+
+  # make sure first bucket reflects the ACTUAL start time
+  defp adjust_range(start_at, [_first | rest]), do: [start_at] ++ rest
+  defp adjust_range(_start_at, []), do: []
 
   # POP next bucket off the stack, or just return when out of buckets
   defp combine_data([], _datas), do: []

--- a/test/controllers/api/bucket_helper_test.exs
+++ b/test/controllers/api/bucket_helper_test.exs
@@ -40,6 +40,21 @@ defmodule Castle.API.BucketHelperTest do
     assert_times(data)
   end
 
+  test "adjust the start time for the first interval bucket", %{to: to} do
+    interval = %BigQuery.Interval{
+      from: get_dtim("2017-03-26T12:00:00Z"),
+      to: to,
+      rollup: BigQuery.TimestampRollups.Hourly,
+      bucket: BigQuery.TimestampRollups.Daily,
+    }
+    data = bucketize([], interval)
+    assert length(data) == 3
+    times = Enum.map(data, &(&1.time))
+    assert_time times, 0, "2017-03-26T12:00:00Z"
+    assert_time times, 1, "2017-03-27T00:00:00Z"
+    assert_time times, 2, "2017-03-28T00:00:00Z"
+  end
+
   test "handles empty first or last buckets", %{buckets: buckets} do
     raw = [%{time: get_dtim("2017-03-27T11:00:00Z"), count: 2}]
     data = bucketize(raw, buckets)


### PR DESCRIPTION
In the case where the first bucket of data is offset from the beginning-of-day/week/month ... return the offset timestamp for the first bucket.

For example, previously, asking for `?interval=1M&from=2017-10-09&to=2017-11-09` would have returned (with 1234 and 5678 being the "partial" downloads for those months):

```js
{
  downloads: [
    ["2017-10-01T00:00:00Z", 1234],
    ["2017-11-01T00:00:00Z", 5678]
  ]
}
```

Now it will return:

```js
{
  downloads: [
    ["2017-10-09T00:00:00Z", 1234],
    ["2017-11-01T00:00:00Z", 5678]
  ]
}
```