### PR TITLE
Less big querying

### DIFF
--- a/lib/big_query/base/query.ex
+++ b/lib/big_query/base/query.ex
@@ -3,9 +3,15 @@ defmodule BigQuery.Base.Query do
   import BigQuery.Base.QueryParams
   import BigQuery.Base.QueryResult
 
-  def query(str), do: query(%{}, str)
+  use Memoize
 
-  def query(queryParams, sql, pageLimit \\ nil) do
+  def query(str), do: query(%{}, str)
+  def query(params, sql), do: query(params, sql, nil)
+  defmemo query(queryParams, sql, pageLimit), expires_in: 10 * 1000 do
+    run_query(queryParams, sql, pageLimit)
+  end
+
+  defp run_query(queryParams, sql, pageLimit) do
     sql
     |> post_params(queryParams, pageLimit)
     |> post("queries")

--- a/lib/plugs/interval/rollups.ex
+++ b/lib/plugs/interval/rollups.ex
@@ -5,10 +5,21 @@ defmodule Castle.Plugs.Interval.Rollups do
   @hourly BigQuery.TimestampRollups.Hourly
   @daily BigQuery.TimestampRollups.Daily
 
-  def parse(%{assigns: %{interval: %{bucket: bucket}}}) do
+  def parse(%{assigns: %{interval: %{from: from, to: to, bucket: bucket}}}) do
     case bucket.name() do
       "HOUR" -> {:ok, @hourly}
-      "DAY" -> {:ok, @hourly}
+      "DAY" ->
+        start_of_hour = Timex.to_unix(@hourly.floor(from))
+        start_of_day = Timex.to_unix(@daily.floor(from))
+        end_of_hour = Timex.to_unix(@hourly.ceiling(to))
+        end_of_day = Timex.to_unix(@daily.ceiling(to))
+
+        # we can rollup by day instead of hour, if starting/ending at 00:00:00
+        if start_of_hour == start_of_day && end_of_hour == end_of_day do
+          {:ok, @daily}
+        else
+          {:ok, @hourly}
+        end
       "WEEK" -> {:ok, @daily}
       "MONTH" -> {:ok, @daily}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Castle.Mixfile do
   defp apps(_), do: apps()
   defp apps, do: [
     :phoenix, :phoenix_pubsub, :phoenix_html, :cowboy, :logger, :gettext,
-    :jose, :httpoison, :timex, :corsica, :prx_auth
+    :jose, :httpoison, :timex, :corsica, :prx_auth, :memoize
   ]
 
   # Specifies which paths to compile per environment.
@@ -50,6 +50,7 @@ defmodule Castle.Mixfile do
      {:redix, ">= 0.6.0"},
      {:corsica, "~> 0.5"},
      {:prx_auth, "~> 0.0.1"},
+     {:memoize, "~> 1.2"},
      {:dotenv, "~> 2.1", only: [:dev, :test]},
      {:mock, "~> 0.3.1", only: :test}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -16,6 +16,7 @@
   "idna": {:hex, :idna, "5.1.0", "d72b4effeb324ad5da3cab1767cb16b17939004e789d8c0ad5b70f3cea20c89a", [:rebar3], [{:unicode_util_compat, "0.3.1", [hex: :unicode_util_compat, repo: "hexpm", optional: false]}], "hexpm"},
   "jose": {:hex, :jose, "1.8.4", "7946d1e5c03a76ac9ef42a6e6a20001d35987afd68c2107bcd8f01a84e75aa73", [:mix, :rebar3], [{:base64url, "~> 0.0.1", [hex: :base64url, repo: "hexpm", optional: false]}], "hexpm"},
   "meck": {:hex, :meck, "0.8.9", "64c5c0bd8bcca3a180b44196265c8ed7594e16bcc845d0698ec6b4e577f48188", [:rebar3], [], "hexpm"},
+  "memoize": {:hex, :memoize, "1.2.5", "aa319c1a08d0564b5f69e4b190412ecab6e3a90b641663d46630e8d9778bb55c", [:mix], [], "hexpm"},
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm"},
   "mime": {:hex, :mime, "1.2.0", "78adaa84832b3680de06f88f0997e3ead3b451a440d183d688085be2d709b534", [:mix], [], "hexpm"},
   "mimerl": {:hex, :mimerl, "1.0.2", "993f9b0e084083405ed8252b99460c4f0563e41729ab42d9074fd5e52439be88", [:rebar3], [], "hexpm"},

--- a/test/plugs/interval/rollups_test.exs
+++ b/test/plugs/interval/rollups_test.exs
@@ -1,11 +1,26 @@
 defmodule Castle.PlugsIntervalRollupsTest do
   use Castle.ConnCase, async: true
+  use Castle.TimeHelpers
+
+  @hourly BigQuery.TimestampRollups.Hourly
+  @daily BigQuery.TimestampRollups.Daily
+  @weekly BigQuery.TimestampRollups.Weekly
+  @monthly BigQuery.TimestampRollups.Monthly
 
   test "gets rollup values from the bucket", %{conn: conn} do
-    assert parse_name(conn, BigQuery.TimestampRollups.Hourly) == "HOUR"
-    assert parse_name(conn, BigQuery.TimestampRollups.Daily) == "HOUR"
-    assert parse_name(conn, BigQuery.TimestampRollups.Weekly) == "DAY"
-    assert parse_name(conn, BigQuery.TimestampRollups.Monthly) == "DAY"
+    assert parse_name(conn, @hourly) == "HOUR"
+    assert parse_name(conn, @daily) == "HOUR"
+    assert parse_name(conn, @weekly) == "DAY"
+    assert parse_name(conn, @monthly) == "DAY"
+  end
+
+  test "rolls up by days when not offset from start-of-day", %{conn: conn} do
+    assert parse_name(conn, @daily, "2018-01-04T00:00:00Z", "2018-01-08T00:00:00Z") == "DAY"
+    assert parse_name(conn, @daily, "2018-01-04T00:00:01Z", "2018-01-08T00:00:00Z") == "DAY"
+    assert parse_name(conn, @daily, "2018-01-04T00:00:00Z", "2018-01-07T23:59:59Z") == "DAY"
+    assert parse_name(conn, @daily, "2018-01-04T01:00:00Z", "2018-01-08T00:00:00Z") == "HOUR"
+    assert parse_name(conn, @daily, "2018-01-03T23:59:59Z", "2018-01-08T00:00:00Z") == "HOUR"
+    assert parse_name(conn, @daily, "2018-01-04T00:00:00Z", "2018-01-08T00:00:01Z") == "HOUR"
   end
 
   test "requires a bucket be defined", %{conn: conn} do
@@ -24,13 +39,23 @@ defmodule Castle.PlugsIntervalRollupsTest do
     {:ok, rollup} = call_parse(conn, bucket)
     rollup.name
   end
+  defp parse_name(conn, bucket, from, to) do
+    {:ok, rollup} = call_parse(conn, bucket, from, to)
+    rollup.name
+  end
 
-  defp call_parse(conn, bucket) do
+  defp call_parse(conn, bucket, from \\ "2018-01-04T00:00:00Z", to \\ "2018-01-08T12:00:00Z") do
     conn
-    |> set_bucket(bucket)
+    |> set_bucket(bucket, from, to)
     |> Castle.Plugs.Interval.Rollups.parse()
   end
 
-  defp set_bucket(conn, nil), do: conn
-  defp set_bucket(conn, bucket), do: Plug.Conn.assign(conn, :interval, %{bucket: bucket})
+  defp set_bucket(conn, nil, _from, _to), do: conn
+  defp set_bucket(conn, bucket, from, to) do
+    Plug.Conn.assign(conn, :interval, %{
+      from: get_dtim(from),
+      to: get_dtim(to),
+      bucket: bucket,
+    })
+  end
 end

--- a/test/plugs/interval_plug_test.exs
+++ b/test/plugs/interval_plug_test.exs
@@ -21,6 +21,14 @@ defmodule Castle.PlugsIntervalTest do
     assert intv.rollup.name == "HOUR"
   end
 
+  test "parses day intervals with a day-rollup", %{conn: conn} do
+    intv = get_interval(conn, "2017-04-01T00:00:00Z", "2017-04-02T23:59:59Z", "1d")
+    assert_time intv.from, "2017-04-01T00:00:00Z"
+    assert_time intv.to, "2017-04-03T00:00:00Z"
+    assert intv.bucket.name == "DAY"
+    assert intv.rollup.name == "DAY"
+  end
+
   test "parses week intervals", %{conn: conn} do
     intv = get_interval(conn, "2017-04-01T14:04:00Z", "2017-04-09T14:05:00Z", "1w")
     assert_time intv.from, "2017-04-01T00:00:00Z"


### PR DESCRIPTION
Hitting the memory limit in ECS prod, when asking for a large (> 90 days) set of daily episodes.

Couple things to maybe help this:

- [x] Memoize bigquery requests (same sql + params will return the same data for 10 seconds)
- [x] When possible (from/to dates that are already rounded to the start/end of day), rollup daily data from plain ol' daily-data ... rather than the 24x hourly data.