### PR TITLE
Rollup for download trends

### DIFF
--- a/lib/castle_web/controllers/api/episode_controller.ex
+++ b/lib/castle_web/controllers/api/episode_controller.ex
@@ -2,15 +2,24 @@ defmodule CastleWeb.API.EpisodeController do
   use CastleWeb, :controller
 
   alias Castle.Rollup.Data.Totals, as: Totals
+  alias Castle.Rollup.Data.Trends, as: Trends
 
   def index(conn, _params) do
     render conn, "index.json", conn: conn, episodes: Totals.episodes(), meta: %{cached: true}
   end
 
   def show(conn, %{"id" => id}) do
-    case Totals.episode(id) do
-      nil -> send_resp conn, 404, "Episode #{id} not found"
-      ep -> render conn, "show.json", conn: conn, episode: ep, meta: %{cached: true}
+    case assemble_data(id) do
+      {nil, _} ->
+        send_resp conn, 404, "Episode #{id} not found"
+      {ep, trends} ->
+        render conn, "show.json", conn: conn, episode: ep, trends: trends, meta: %{cached: true}
     end
+  end
+
+  defp assemble_data(id) do
+    t1 = Task.async(fn -> Totals.episode(id) end)
+    t2 = Task.async(fn -> Trends.episode(id) end)
+    {Task.await(t1), Task.await(t2)}
   end
 end

--- a/lib/castle_web/controllers/api/podcast_controller.ex
+++ b/lib/castle_web/controllers/api/podcast_controller.ex
@@ -2,6 +2,7 @@ defmodule CastleWeb.API.PodcastController do
   use CastleWeb, :controller
 
   alias Castle.Rollup.Data.Totals, as: Totals
+  alias Castle.Rollup.Data.Trends, as: Trends
 
   plug Castle.Plugs.ParseInt, "id" when action == :show
 
@@ -10,9 +11,17 @@ defmodule CastleWeb.API.PodcastController do
   end
 
   def show(conn, %{"id" => id}) do
-    case Totals.podcast(id) do
-      nil -> send_resp conn, 404, "Podcast #{id} not found"
-      pod -> render conn, "show.json", conn: conn, podcast: pod, meta: %{cached: true}
+    case assemble_data(id) do
+      {nil, _} ->
+        send_resp conn, 404, "Podcast #{id} not found"
+      {pod, trends} ->
+        render conn, "show.json", conn: conn, podcast: pod, trends: trends, meta: %{cached: true}
     end
+  end
+
+  defp assemble_data(id) do
+    t1 = Task.async(fn -> Totals.podcast(id) end)
+    t2 = Task.async(fn -> Trends.podcast(id) end)
+    {Task.await(t1), Task.await(t2)}
   end
 end

--- a/lib/castle_web/views/api/episode_view.ex
+++ b/lib/castle_web/views/api/episode_view.ex
@@ -5,7 +5,7 @@ defmodule CastleWeb.API.EpisodeView do
 
   def render("index.json", %{conn: conn, episodes: episodes, meta: meta}) do
     limit = Enum.min [@limit, length(episodes)]
-    items = episodes |> Enum.slice(0, limit) |> Enum.map(&(episode_json(&1, conn)))
+    items = episodes |> Enum.slice(0, limit) |> Enum.map(&(episode_json(&1, nil, conn)))
     %{
       count: limit,
       total: length(episodes),
@@ -16,19 +16,17 @@ defmodule CastleWeb.API.EpisodeView do
     }
   end
 
-  def render("show.json", %{conn: conn, episode: episode, meta: meta}) do
-    episode_json(episode, conn)
+  def render("show.json", %{conn: conn, episode: episode, trends: trends, meta: meta}) do
+    episode_json(episode, trends, conn)
     |> put_podcast_link(conn, episode)
     |> Map.put(:meta, meta)
   end
 
-  defp episode_json(%{feeder_episode: guid, count: count}, conn) do
+  defp episode_json(%{feeder_episode: guid, count: count}, trends, conn) do
     %{
       guid: guid,
       name: guid,
-      downloads: %{
-        total: count,
-      },
+      downloads: trends_json(count, trends),
       _links: %{
         self: %{
           href: api_episode_path(conn, :show, guid),
@@ -53,4 +51,15 @@ defmodule CastleWeb.API.EpisodeView do
     put_in json, [:_links, "prx:podcast"], %{href: api_podcast_path(conn, :show, id)}
   end
   defp put_podcast_link(json, _conn, _episode), do: json
+
+  defp trends_json(total_count, nil), do: %{total: total_count}
+  defp trends_json(total_count, trends) do
+    %{
+      total: total_count,
+      today: Map.get(trends, :today, 0),
+      yesterday: Map.get(trends, :yesterday, 0),
+      this7days: Map.get(trends, :this7, 0),
+      previous7days: Map.get(trends, :last7, 0),
+    }
+  end
 end

--- a/lib/castle_web/views/api/podcast_view.ex
+++ b/lib/castle_web/views/api/podcast_view.ex
@@ -5,7 +5,7 @@ defmodule CastleWeb.API.PodcastView do
 
   def render("index.json", %{conn: conn, podcasts: podcasts, meta: meta}) do
     limit = Enum.min [@limit, length(podcasts)]
-    items = podcasts |> Enum.slice(0, limit) |> Enum.map(&(podcast_json(&1, conn)))
+    items = podcasts |> Enum.slice(0, limit) |> Enum.map(&(podcast_json(&1, nil, conn)))
     %{
       count: limit,
       total: length(podcasts),
@@ -16,17 +16,15 @@ defmodule CastleWeb.API.PodcastView do
     }
   end
 
-  def render("show.json", %{conn: conn, podcast: podcast, meta: meta}) do
-    podcast_json(podcast, conn) |> Map.put(:meta, meta)
+  def render("show.json", %{conn: conn, podcast: podcast, trends: trends, meta: meta}) do
+    podcast_json(podcast, trends, conn) |> Map.put(:meta, meta)
   end
 
-  defp podcast_json(%{feeder_podcast: id, count: count}, conn) do
+  defp podcast_json(%{feeder_podcast: id, count: count}, trends, conn) do
     %{
       id: id,
       name: id,
-      downloads: %{
-        total: count,
-      },
+      downloads: trends_json(count, trends),
       _links: %{
         self: %{
           href: api_podcast_path(conn, :show, id),
@@ -44,6 +42,17 @@ defmodule CastleWeb.API.PodcastView do
           templated: true,
         },
       }
+    }
+  end
+
+  defp trends_json(total_count, nil), do: %{total: total_count}
+  defp trends_json(total_count, trends) do
+    %{
+      total: total_count,
+      today: Map.get(trends, :today, 0),
+      yesterday: Map.get(trends, :yesterday, 0),
+      this7days: Map.get(trends, :this7, 0),
+      previous7days: Map.get(trends, :last7, 0),
     }
   end
 end

--- a/lib/redis/partition_cache.ex
+++ b/lib/redis/partition_cache.ex
@@ -1,4 +1,6 @@
 defmodule Castle.Redis.PartitionCache do
+  use Memoize
+
   alias Castle.Redis.Conn, as: Conn
 
   def partition(key, combiner_fn, worker_fns) do
@@ -6,7 +8,7 @@ defmodule Castle.Redis.PartitionCache do
   end
   def partition(key, fns), do: partition(key, fn(parts) -> parts end, fns)
 
-  def partition_get(key, num_parts, combiner_fn) do
+  defmemo partition_get(key, num_parts, combiner_fn), expires_in: 300 * 1000 do
     parts = Enum.map 0..(num_parts - 1), fn(index) ->
       case Conn.get("#{key}.#{index}") do
         nil -> {[], %{cached: true}}

--- a/lib/rollup/data/trends_data.ex
+++ b/lib/rollup/data/trends_data.ex
@@ -1,0 +1,34 @@
+defmodule Castle.Rollup.Data.Trends do
+  import Castle.Rollup.Jobs.Trends
+
+  def podcast(id) do
+    {result, _meta} = get()
+    result
+    |> Enum.filter(&(&1.feeder_podcast == id))
+    |> sum_fields()
+  end
+
+  def episode(guid) do
+    {result, _meta} = get()
+    result
+    |> Enum.filter(&(&1.feeder_episode == guid))
+    |> sum_fields()
+  end
+
+  defp sum_fields([]), do: sum_fields(%{}, [%{}])
+  defp sum_fields(data), do: sum_fields(%{}, data)
+  defp sum_fields(acc, [first | rest]) do
+    acc
+    |> sum_field(first, :last7)
+    |> sum_field(first, :this7)
+    |> sum_field(first, :yesterday)
+    |> sum_field(first, :today)
+    |> sum_fields(rest)
+  end
+  defp sum_fields(acc, []), do: acc
+
+  defp sum_field(left, right, key) do
+    sum = Map.get(left, key, 0) + Map.get(right, key, 0)
+    Map.put(left, key, sum)
+  end
+end

--- a/lib/rollup/jobs/trends_job.ex
+++ b/lib/rollup/jobs/trends_job.ex
@@ -1,0 +1,63 @@
+defmodule Castle.Rollup.Jobs.Trends do
+  # @redis Application.get_env(:castle, :redis)
+  import Castle.Redis.PartitionCache
+
+  # old - all days before today
+  # new - just data for today
+  def run() do
+    partition "rollup.trends", &Castle.Rollup.Jobs.Trends.combine/1, [
+      {ttl_eod(Timex.now()), &Castle.Rollup.Jobs.Trends.old_part/0},
+      {300, &Castle.Rollup.Jobs.Trends.new_part/1}]
+  end
+
+  def ttl_eod(now) do
+    end_of_day = Timex.end_of_day(now) |> Timex.shift(microseconds: 1)
+    Timex.diff(end_of_day, now, :seconds)
+  end
+
+  def get() do
+    partition_get "rollup.trends", 2, &Castle.Rollup.Jobs.Trends.combine/1
+  end
+
+  def combine(parts), do: parts
+
+  def old_part() do
+    sql = sql("_PARTITIONTIME >= @lower AND _PARTITIONTIME < @upper")
+    end_dtim = Timex.beginning_of_day(Timex.now())
+    start_dtim = Timex.shift(end_dtim, days: -13)
+    params = params(%{lower: start_dtim, upper: end_dtim})
+    {result, meta} = BigQuery.Base.Query.query(params, sql)
+    {end_dtim, result, Map.put(meta, :job, [{nil, end_dtim}])}
+  end
+
+  def new_part(start_dtim) do
+    sql = sql("_PARTITIONTIME >= @lower")
+    params = params(%{lower: start_dtim})
+    {result, meta} = BigQuery.Base.Query.query(params, sql)
+    {nil, result, Map.put(meta, :job, [{start_dtim, nil}])}
+  end
+
+  defp sql(where_sql) do
+    """
+      SELECT feeder_podcast, feeder_episode,
+        COUNTIF(timestamp >= @last7 AND timestamp < @this7) as last7,
+        COUNTIF(timestamp >= @this7) as this7,
+        COUNTIF(timestamp >= @yesterday AND timestamp < @today) as yesterday,
+        COUNTIF(timestamp >= @today) as today
+      FROM #{Env.get(:bq_downloads_table)}
+      WHERE is_duplicate = false AND feeder_podcast IS NOT NULL
+      AND feeder_episode IS NOT NULL AND #{where_sql}
+      GROUP BY feeder_podcast, feeder_episode
+    """
+  end
+
+  defp params(params) do
+    today = Timex.beginning_of_day(Timex.now())
+    %{
+      last7: Timex.shift(today, days: -13),
+      this7: Timex.shift(today, days: -6),
+      yesterday: Timex.shift(today, days: -1),
+      today: today,
+    } |> Map.merge(params)
+  end
+end

--- a/lib/rollup/jobs/trends_job.ex
+++ b/lib/rollup/jobs/trends_job.ex
@@ -1,5 +1,5 @@
 defmodule Castle.Rollup.Jobs.Trends do
-  # @redis Application.get_env(:castle, :redis)
+  # TODO: import "public" redis api from the application
   import Castle.Redis.PartitionCache
 
   # old - all days before today

--- a/lib/rollup/worker.ex
+++ b/lib/rollup/worker.ex
@@ -5,6 +5,7 @@ defmodule Castle.Rollup.Worker do
 
   @jobs [
     {Castle.Rollup.Jobs.Totals, :run, []},
+    {Castle.Rollup.Jobs.Trends, :run, []},
   ]
 
   def start_link do

--- a/test/rollup/data/trends_data_test.exs
+++ b/test/rollup/data/trends_data_test.exs
@@ -1,0 +1,51 @@
+defmodule Castle.Rollup.Data.TrendsTest do
+  use Castle.ConnCase, async: false
+
+  import Castle.Rollup.Data.Trends
+
+  import Mock
+
+  # TODO: this doesn't work unless you've "mix castle.rollup"d first
+  # @tag :external
+  # test "actually works" do
+  #   pod_trends = podcast(25)
+  #   assert pod_trends.last7 > 1000
+  #   assert pod_trends.this7 > 1000
+  #   assert pod_trends.yesterday > 100
+  #   assert pod_trends.today > 1
+  #
+  #   ep_trends = episode("5209720b-e71e-454a-abaf-8ffaf542ac67")
+  #   assert ep_trends.last7 > 100
+  #   assert ep_trends.this7 > 100
+  #   assert ep_trends.yesterday > 10
+  #   assert ep_trends.today > 1
+  # end
+
+  test "gets podcast trends" do
+    with_mock Castle.Rollup.Jobs.Trends, fake_getter() do
+      assert podcast(5) == %{last7: 6, this7: 0, today: 3, yesterday: 1}
+      assert podcast(6) == %{last7: 0, this7: 0, today: 11, yesterday: 0}
+      assert podcast(7) == %{last7: 0, this7: 0, today: 0, yesterday: 0}
+    end
+  end
+
+  test "gets episode trends" do
+    with_mock Castle.Rollup.Jobs.Trends, fake_getter() do
+      assert episode("guid1") == %{last7: 2, this7: 0, today: 0, yesterday: 1}
+      assert episode("guid2") == %{last7: 4, this7: 0, today: 3, yesterday: 0}
+      assert episode("guid3") == %{last7: 0, this7: 0, today: 11, yesterday: 0}
+      assert episode("guid4") == %{last7: 0, this7: 0, today: 0, yesterday: 0}
+    end
+  end
+
+  defp fake_getter do
+    results = [
+      %{feeder_episode: "guid2", feeder_podcast: 5, last7: 4},
+      %{feeder_episode: "guid2", feeder_podcast: 5, today: 3},
+      %{feeder_episode: "guid1", feeder_podcast: 5, last7: 2, yesterday: 1},
+      %{feeder_episode: "guid3", feeder_podcast: 6, today: 11},
+    ]
+    [get: fn() -> {results, %{cached: true}} end]
+  end
+
+end

--- a/test/rollup/jobs/trends_job_test.exs
+++ b/test/rollup/jobs/trends_job_test.exs
@@ -1,5 +1,6 @@
 defmodule Castle.Rollup.Jobs.TrendsTest do
   use Castle.BigQueryCase, async: true
+  use Castle.TimeHelpers
 
   import Castle.Rollup.Jobs.Trends
 
@@ -13,5 +14,10 @@ defmodule Castle.Rollup.Jobs.TrendsTest do
     ]
     results = combine(datas)
     assert results == datas
+  end
+
+  test "uses a TTL at the end of today" do
+    assert ttl_eod(get_dtim("2017-03-22T00:00:00Z")) == 86400
+    assert ttl_eod(get_dtim("2017-03-22T23:59:59Z")) == 1
   end
 end

--- a/test/rollup/jobs/trends_job_test.exs
+++ b/test/rollup/jobs/trends_job_test.exs
@@ -1,0 +1,17 @@
+defmodule Castle.Rollup.Jobs.TrendsTest do
+  use Castle.BigQueryCase, async: true
+
+  import Castle.Rollup.Jobs.Trends
+
+  test "does nothing to combine results" do
+    datas = [
+      %{feeder_podcast: 123, feeder_episode: "123-1", last7: 22, this7: 11, yesterday: 4, today: 0},
+      %{feeder_podcast: 123, feeder_episode: "123-2", last7: 0, this7: 0, yesterday: 0, today: 2},
+      %{feeder_podcast: 456, feeder_episode: "456-1", this7: 12},
+      %{feeder_podcast: 123, feeder_episode: "123-2", last7: 4, this7: 0, yesterday: 1, today: 0},
+      %{feeder_podcast: 123, feeder_episode: "123-1", last7: 0, yesterday: 1, today: 2},
+    ]
+    results = combine(datas)
+    assert results == datas
+  end
+end

--- a/test/views/api/episode_view_test.exs
+++ b/test/views/api/episode_view_test.exs
@@ -15,9 +15,14 @@ defmodule Castle.API.EpisodeViewTest do
   end
 
   test "show.json", %{conn: conn} do
-    doc = render("show.json", %{conn: conn, episode: test_episode("foo"), meta: %{}})
+    trends = %{today: 1, this7: 2, last7: 3}
+    doc = render("show.json", %{conn: conn, episode: test_episode("foo"), trends: trends, meta: %{}})
     assert doc.guid == "foo"
     assert doc.downloads.total == 999
+    assert doc.downloads.today == 1
+    assert doc.downloads.yesterday == 0
+    assert doc.downloads.this7days == 2
+    assert doc.downloads.previous7days == 3
     assert doc._links["prx:podcast"].href =~ ~r/podcasts\/123/
   end
 

--- a/test/views/api/podcast_view_test.exs
+++ b/test/views/api/podcast_view_test.exs
@@ -15,9 +15,14 @@ defmodule Castle.API.PodcastViewTest do
   end
 
   test "show.json", %{conn: conn} do
-    doc = render("show.json", %{conn: conn, podcast: test_podcast("foo"), meta: %{}})
+    trends = %{today: 1, yesterday: 2, this7: 3, last7: 4}
+    doc = render("show.json", %{conn: conn, podcast: test_podcast("foo"), trends: trends, meta: %{}})
     assert doc.id == "foo"
     assert doc.downloads.total == 999
+    assert doc.downloads.today == 1
+    assert doc.downloads.yesterday == 2
+    assert doc.downloads.this7days == 3
+    assert doc.downloads.previous7days == 4
   end
 
   defp test_podcasts do


### PR DESCRIPTION
See #52.

Updates podcast/episode `show` views to include:

```
"downloads": {
  "yesterday": 64,
  "total": 86007,
  "today": 45,
  "this7days": 425,
  "previous7days": 487
}
```

(Totals was already in there).