### PR TITLE
Fix podcast totals rollup

### DIFF
--- a/lib/redis/hash_cache.ex
+++ b/lib/redis/hash_cache.ex
@@ -67,6 +67,7 @@ defmodule Castle.Redis.HashCache do
     |> Enum.into(%{})
   end
   def stringify_key(k) when is_atom(k), do: Atom.to_string(k)
+  def stringify_key(k) when is_number(k), do: "#{k}"
   def stringify_key(k), do: k
 
   defp merge(left, right) do

--- a/test/redis/hash_cache_test.exs
+++ b/test/redis/hash_cache_test.exs
@@ -89,6 +89,16 @@ defmodule Castle.RedisHashCacheTest do
     assert run_fetch("#{@key}.dne", "foo", 3, today) == nil
   end
 
+  test "stringifies hash keys" do
+    data = stringify_keys(%{
+      "str" => "value1",
+      :atom => "value2",
+      3 => "value3",
+      "4" => "value4",
+    })
+    assert Map.keys(data) == ["3", "4", "atom", "str"]
+  end
+
   defp run_fetch(key, field, num, expected_time) do
     hash_fetch(key, field, fn(from) ->
       assert_time from, expected_time


### PR DESCRIPTION
Was hitting an issue with string-vs-int keys.  Any data coming back from redis has string keys, but any data coming from bigquery has int keys.  So when I merged the 2 together, I'd get something like:

```
%{
  1234 => 33333,
  "1234" => 444,
}
```

It _should_ have been adding those 2 numbers together, so that podcast-id 1234 has 33777 downloads for that period.  Instead, it tries to hset both of them in redis, and the last one wins ... which is why we're seeing such deflated total downloads for podcasts but not episodes.