### PR TITLE
Geo data rollups

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,21 +93,28 @@ mix feeder.sync [--lock,--all,--force]
 
 ### Downloads Rollup
 
-This task queries BigQuery for hourly downloads on a single day, and inserts
-that day of data into Postgres.  It also updates the `rollup_logs` to keep track
-of which days have already been rolled up.
+These tasks query BigQuery for `dt_downloads` on a single day, and inserts that
+day of data into Postgres.  It also updates the `rollup_logs` to keep  track
+track of which days have already been rolled up, and marks them as "complete"
+days if that day is in the past.
 
-By default, this task will find 5 incomplete days (not present in `rollup_logs`)
+The only exception to this is the `monthly_downloads` table, which is calculated
+from the `hourly_downloads` to provide more efficient access to podcast/episode
+"total" downloads, without having to scan every partition of hourly data.
+
+By default, most tasks will find 5 incomplete days (not present in `rollup_logs`)
 and process those.  But you can change that number with the `--count 99` flag.  
-Or explicitly rollup a certain day with `--date 20180425`.
+Or explicitly rollup a certain day with `--date 20180425`.  Rollup operations
+are idempotent, you can run them repeatedly for the same day/month.
 
-Since the rollup operation is idempotent, you can run it on the current day
-repeatedly.  But a record will only be added to the `rollup_logs` table 15
-minutes after midnight, to make sure BigQuery is completely accurate before
-marking the day as "complete".
+These are all the rollup tasks available:
 
 ```
-mix castle.rollup.downloads [--lock,--date [YYYYMMDD],--count [INT]]
+mix castle.rollup.hourly [--lock,--date [YYYYMMDD],--count [INT]]
+mix castle.rollup.monthly [--lock,--date [YYYYMMDD],--count [INT]]
+mix castle.rollup.geocountries [--lock,--date [YYYYMMDD],--count [INT]]
+mix castle.rollup.geometros [--lock,--date [YYYYMMDD],--count [INT]]
+mix castle.rollup.geosubdivs [--lock,--date [YYYYMMDD],--count [INT]]
 ```
 
 ## Testing

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -43,7 +43,7 @@ config :castle, :redis, Castle.Redis.Api
 config :castle, Castle.Scheduler,
   jobs: [
     # {"* * * * *", {Feeder.Sync,         :run, [["--lock"]]}},
-    # {"* * * * *", {Rollup.Downloads,    :run, [["--lock"]]}},
+    # {"* * * * *", {Rollup.Hourly,       :run, [["--lock"]]}},
     # {"* * * * *", {Rollup.Monthly,      :run, [["--lock"]]}},
     # {"* * * * *", {Rollup.Geocountries, :run, [["--lock"]]}},
     # {"* * * * *", {Rollup.Geometros,    :run, [["--lock"]]}},

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+alias Mix.Tasks.Feeder, as: Feeder
+alias Mix.Tasks.Castle.Rollup, as: Rollup
+
 # For development, we disable any cache and enable
 # debugging and code reloading.
 #
@@ -37,8 +40,12 @@ config :phoenix, :stacktrace_depth, 20
 config :castle, :redis, Castle.Redis.Api
 
 # Uncomment to run jobs in development
-# config :castle, Castle.Scheduler,
-#   jobs: [
-#     {"* * * * *", {Mix.Tasks.Castle.Rollup.Downloads, :run, [["--lock"]]}},
-#     {"* * * * *", {Mix.Tasks.Feeder.Sync, :run, [["--lock"]]}},
-#   ]
+config :castle, Castle.Scheduler,
+  jobs: [
+    # {"* * * * *", {Feeder.Sync,         :run, [["--lock"]]}},
+    # {"* * * * *", {Rollup.Downloads,    :run, [["--lock"]]}},
+    # {"* * * * *", {Rollup.Monthly,      :run, [["--lock"]]}},
+    # {"* * * * *", {Rollup.Geocountries, :run, [["--lock"]]}},
+    # {"* * * * *", {Rollup.Geometros,    :run, [["--lock"]]}},
+    # {"* * * * *", {Rollup.Geosubdivs,   :run, [["--lock"]]}},
+  ]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -28,7 +28,7 @@ config :castle, :redis, Castle.Redis.Api
 config :castle, Castle.Scheduler,
   jobs: [
     {"* * * * *",     {Feeder.Sync,         :run, [["--lock"]]}},
-    {"15,45 * * * *", {Rollup.Downloads,    :run, [["--lock"]]}},
+    {"15,45 * * * *", {Rollup.Hourly,       :run, [["--lock"]]}},
     {"15 6 * * *",    {Rollup.Monthly,      :run, [["--lock"]]}},
     {"20,50 * * * *", {Rollup.Geocountries, :run, [["--lock"]]}},
     {"25,55 * * * *", {Rollup.Geometros,    :run, [["--lock"]]}},

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,5 +1,8 @@
 use Mix.Config
 
+alias Mix.Tasks.Feeder, as: Feeder
+alias Mix.Tasks.Castle.Rollup, as: Rollup
+
 # For production, we configure the host to read the PORT
 # from the system environment. Therefore, you will need
 # to set PORT=80 before running your server.
@@ -24,8 +27,12 @@ config :castle, :redis, Castle.Redis.Api
 # Scheduled jobs
 config :castle, Castle.Scheduler,
   jobs: [
-    {"15,45 * * * *", {Mix.Tasks.Castle.Rollup.Downloads, :run, [["--lock"]]}},
-    {"* * * * *", {Mix.Tasks.Feeder.Sync, :run, [["--lock"]]}},
+    {"* * * * *",     {Feeder.Sync,         :run, [["--lock"]]}},
+    {"15,45 * * * *", {Rollup.Downloads,    :run, [["--lock"]]}},
+    {"15 6 * * *",    {Rollup.Monthly,      :run, [["--lock"]]}},
+    {"20,50 * * * *", {Rollup.Geocountries, :run, [["--lock"]]}},
+    {"25,55 * * * *", {Rollup.Geometros,    :run, [["--lock"]]}},
+    {"30,0 * * * *",  {Rollup.Geosubdivs,   :run, [["--lock"]]}},
   ]
 
 # ## SSL Support

--- a/lib/big_query/rollup.ex
+++ b/lib/big_query/rollup.ex
@@ -5,6 +5,8 @@ defmodule BigQuery.Rollup do
 
   defdelegate hourly_downloads(), to: BigQuery.Rollup.HourlyDownloads, as: :query
   defdelegate hourly_downloads(d), to: BigQuery.Rollup.HourlyDownloads, as: :query
+  defdelegate daily_geo_subdivs(), to: BigQuery.Rollup.DailyGeoSubdivs, as: :query
+  defdelegate daily_geo_subdivs(d), to: BigQuery.Rollup.DailyGeoSubdivs, as: :query
 
   def for_day(dtim, query_fn) do
     now = Timex.now()

--- a/lib/big_query/rollup.ex
+++ b/lib/big_query/rollup.ex
@@ -1,21 +1,21 @@
 defmodule BigQuery.Rollup do
-  import BigQuery.Base.Query
 
   # a day isn't "complete" until this many seconds after it's over
   @buffer_seconds 900
 
-  # get a single day of downloads bucketed by hours
-  def hourly_downloads(), do: hourly_downloads(Timex.now)
-  def hourly_downloads(dtim) do
+  defdelegate hourly_downloads(), to: BigQuery.Rollup.HourlyDownloads, as: :query
+  defdelegate hourly_downloads(d), to: BigQuery.Rollup.HourlyDownloads, as: :query
+
+  def for_day(dtim, query_fn) do
     now = Timex.now()
     day = Timex.beginning_of_day(dtim)
     case completion_state(day, now) do
       :none ->
         {[], %{day: day, complete: false, hours_complete: 0}}
       :partial ->
-        query_hourly_downloads(day) |> set_meta(:complete, false) |> set_meta(:hours_complete, hours_complete(now))
+        query_fn.(day) |> set_meta(:day, day) |> set_meta(:complete, false) |> set_meta(:hours_complete, hours_complete(now))
       :complete ->
-        query_hourly_downloads(day) |> set_meta(:complete, true)
+        query_fn.(day) |> set_meta(:day, day) |> set_meta(:complete, true)
     end
   end
 
@@ -31,30 +31,6 @@ defmodule BigQuery.Rollup do
   end
 
   def hours_complete(now), do: Timex.shift(now, seconds: -@buffer_seconds).hour
-
-  defp query_hourly_downloads(day) do
-    sql = """
-      SELECT
-        ANY_VALUE(feeder_podcast) as podcast_id,
-        feeder_episode as episode_guid,
-        EXTRACT(HOUR from timestamp) as hour,
-        count(*) as count
-      FROM dt_downloads
-      WHERE EXTRACT(DATE from timestamp) = @date_str AND is_duplicate = false
-        AND feeder_podcast IS NOT NULL AND feeder_episode IS NOT NULL
-      GROUP BY feeder_episode, hour
-      """
-    {:ok, date_str} = Timex.format(day, "{YYYY}-{0M}-{0D}")
-    {results, meta} = query(%{date_str: date_str}, sql)
-    {
-      Enum.map(results, &(format_result(&1, day))),
-      Map.put(meta, :day, day)
-    }
-  end
-
-  defp format_result(row, day) do
-    Map.put(row, :hour, Timex.shift(day, hours: row.hour))
-  end
 
   defp set_meta({results, meta}, key, value) do
     {results, Map.put(meta, key, value)}

--- a/lib/big_query/rollup.ex
+++ b/lib/big_query/rollup.ex
@@ -5,6 +5,10 @@ defmodule BigQuery.Rollup do
 
   defdelegate hourly_downloads(), to: BigQuery.Rollup.HourlyDownloads, as: :query
   defdelegate hourly_downloads(d), to: BigQuery.Rollup.HourlyDownloads, as: :query
+  defdelegate daily_geo_countries(), to: BigQuery.Rollup.DailyGeoCountries, as: :query
+  defdelegate daily_geo_countries(d), to: BigQuery.Rollup.DailyGeoCountries, as: :query
+  defdelegate daily_geo_metros(), to: BigQuery.Rollup.DailyGeoMetros, as: :query
+  defdelegate daily_geo_metros(d), to: BigQuery.Rollup.DailyGeoMetros, as: :query
   defdelegate daily_geo_subdivs(), to: BigQuery.Rollup.DailyGeoSubdivs, as: :query
   defdelegate daily_geo_subdivs(d), to: BigQuery.Rollup.DailyGeoSubdivs, as: :query
 

--- a/lib/big_query/rollup/daily_geo_countries.ex
+++ b/lib/big_query/rollup/daily_geo_countries.ex
@@ -1,4 +1,4 @@
-defmodule BigQuery.Rollup.DailyGeoSubdivs do
+defmodule BigQuery.Rollup.DailyGeoCountries do
   alias BigQuery.Base.Query, as: Query
 
   def query(), do: query(Timex.now)
@@ -15,13 +15,12 @@ defmodule BigQuery.Rollup.DailyGeoSubdivs do
       ANY_VALUE(feeder_podcast) as podcast_id,
       feeder_episode as episode_id,
       country_iso_code,
-      subdivision_1_iso_code,
       count(*) as count
-    FROM dt_downloads JOIN production.geonames ON (city_geoname_id = geoname_id)
+    FROM dt_downloads JOIN production.geonames ON (country_geoname_id = geoname_id)
     WHERE EXTRACT(DATE from timestamp) = @date_str AND is_duplicate = false
       AND feeder_podcast IS NOT NULL AND feeder_episode IS NOT NULL
-      AND country_iso_code IS NOT NULL AND subdivision_1_iso_code IS NOT NULL
-    GROUP BY feeder_episode, country_iso_code, subdivision_1_iso_code
+      AND country_iso_code IS NOT NULL
+    GROUP BY feeder_episode, country_iso_code
     """
   end
 

--- a/lib/big_query/rollup/daily_geo_metros.ex
+++ b/lib/big_query/rollup/daily_geo_metros.ex
@@ -1,4 +1,4 @@
-defmodule BigQuery.Rollup.DailyGeoSubdivs do
+defmodule BigQuery.Rollup.DailyGeoMetros do
   alias BigQuery.Base.Query, as: Query
 
   def query(), do: query(Timex.now)
@@ -14,14 +14,13 @@ defmodule BigQuery.Rollup.DailyGeoSubdivs do
     SELECT
       ANY_VALUE(feeder_podcast) as podcast_id,
       feeder_episode as episode_id,
-      country_iso_code,
-      subdivision_1_iso_code,
+      metro_code,
       count(*) as count
     FROM dt_downloads JOIN production.geonames ON (city_geoname_id = geoname_id)
     WHERE EXTRACT(DATE from timestamp) = @date_str AND is_duplicate = false
       AND feeder_podcast IS NOT NULL AND feeder_episode IS NOT NULL
-      AND country_iso_code IS NOT NULL AND subdivision_1_iso_code IS NOT NULL
-    GROUP BY feeder_episode, country_iso_code, subdivision_1_iso_code
+      AND metro_code IS NOT NULL
+    GROUP BY feeder_episode, metro_code
     """
   end
 

--- a/lib/big_query/rollup/daily_geo_subdivs.ex
+++ b/lib/big_query/rollup/daily_geo_subdivs.ex
@@ -1,0 +1,35 @@
+defmodule BigQuery.Rollup.DailyGeoSubdivs do
+  alias BigQuery.Base.Query, as: Query
+
+  def query(), do: query(Timex.now)
+  def query(dtim) do
+    BigQuery.Rollup.for_day dtim, fn(day) ->
+      Query.query(%{from_date: day, to_date: Timex.shift(day, days: 1)}, sql()) |> format_results(day)
+    end
+  end
+
+  defp sql do
+    """
+    SELECT
+      ANY_VALUE(feeder_podcast) as podcast_id,
+      feeder_episode as episode_id,
+      country_iso_code,
+      subdivision_1_iso_code,
+      count(*) as count
+    FROM dt_downloads JOIN production.geonames ON (city_geoname_id = geoname_id)
+    WHERE timestamp >= @from_date AND timestamp < @to_date AND is_duplicate = false
+      AND feeder_podcast IS NOT NULL AND feeder_episode IS NOT NULL
+      AND country_iso_code IS NOT NULL AND subdivision_1_iso_code IS NOT NULL
+    GROUP BY feeder_episode, country_iso_code, subdivision_1_iso_code
+    """
+  end
+
+  defp format_results({rows, meta}, from) do
+    day = Timex.beginning_of_day(from) |> Timex.to_date()
+    {Enum.map(rows, &(format_result(&1, day))), meta}
+  end
+
+  defp format_result(row, day) do
+    Map.put(row, :day, day)
+  end
+end

--- a/lib/big_query/rollup/hourly_downloads.ex
+++ b/lib/big_query/rollup/hourly_downloads.ex
@@ -1,0 +1,35 @@
+defmodule BigQuery.Rollup.HourlyDownloads do
+  alias BigQuery.Base.Query, as: Query
+
+  def query(), do: query(Timex.now)
+  def query(dtim) do
+    BigQuery.Rollup.for_day dtim, fn(day) ->
+      {:ok, date_str} = Timex.format(day, "{YYYY}-{0M}-{0D}")
+      Query.query(%{date_str: date_str}, sql()) |> format_results(day)
+    end
+  end
+
+  defp sql do
+    """
+    SELECT
+      ANY_VALUE(feeder_podcast) as podcast_id,
+      feeder_episode as episode_id,
+      EXTRACT(HOUR from timestamp) as hour,
+      count(*) as count
+    FROM dt_downloads
+    WHERE EXTRACT(DATE from timestamp) = @date_str AND is_duplicate = false
+      AND feeder_podcast IS NOT NULL AND feeder_episode IS NOT NULL
+    GROUP BY feeder_episode, hour
+    """
+  end
+
+  defp format_results({rows, meta}, day) do
+    {Enum.map(rows, &(format_result(&1, day))), meta}
+  end
+
+  defp format_result(%{hour: hour} = row, day) do
+    row
+    |> Map.put(:dtim, Timex.shift(day, hours: hour))
+    |> Map.delete(:hour)
+  end
+end

--- a/lib/castle/daily_geo_country.ex
+++ b/lib/castle/daily_geo_country.ex
@@ -1,14 +1,13 @@
-defmodule Castle.DailyGeoSubdiv do
+defmodule Castle.DailyGeoCountry do
   use Ecto.Schema
   import Ecto.Changeset
 
   @primary_key false
 
-  schema "daily_geo_subdivs" do
+  schema "daily_geo_countries" do
     field :podcast_id, :integer
     field :episode_id, :binary_id
     field :country_iso_code, :string
-    field :subdivision_1_iso_code, :string
     field :day, :date
     field :count, :integer
   end
@@ -16,8 +15,8 @@ defmodule Castle.DailyGeoSubdiv do
   @doc false
   def changeset(download, attrs) do
     download
-    |> cast(attrs, [:podcast_id, :episode_id, :country_iso_code, :subdivision_1_iso_code, :day, :count])
-    |> validate_required([:podcast_id, :episode_id, :country_iso_code, :subdivision_1_iso_code, :day, :count])
+    |> cast(attrs, [:podcast_id, :episode_id, :country_iso_code, :day, :count])
+    |> validate_required([:podcast_id, :episode_id, :country_iso_code, :day, :count])
   end
 
   def upsert(row), do: upsert_all([row])
@@ -29,7 +28,7 @@ defmodule Castle.DailyGeoSubdiv do
     |> Enum.sum()
   end
   def upsert_all(rows) do
-    Castle.Repo.insert_all Castle.DailyGeoSubdiv, rows
+    Castle.Repo.insert_all Castle.DailyGeoCountry, rows
     length(rows)
   end
 end

--- a/lib/castle/daily_geo_metro.ex
+++ b/lib/castle/daily_geo_metro.ex
@@ -1,14 +1,13 @@
-defmodule Castle.DailyGeoSubdiv do
+defmodule Castle.DailyGeoMetro do
   use Ecto.Schema
   import Ecto.Changeset
 
   @primary_key false
 
-  schema "daily_geo_subdivs" do
+  schema "daily_geo_metros" do
     field :podcast_id, :integer
     field :episode_id, :binary_id
-    field :country_iso_code, :string
-    field :subdivision_1_iso_code, :string
+    field :metro_code, :integer
     field :day, :date
     field :count, :integer
   end
@@ -16,8 +15,8 @@ defmodule Castle.DailyGeoSubdiv do
   @doc false
   def changeset(download, attrs) do
     download
-    |> cast(attrs, [:podcast_id, :episode_id, :country_iso_code, :subdivision_1_iso_code, :day, :count])
-    |> validate_required([:podcast_id, :episode_id, :country_iso_code, :subdivision_1_iso_code, :day, :count])
+    |> cast(attrs, [:podcast_id, :episode_id, :metro_code, :day, :count])
+    |> validate_required([:podcast_id, :episode_id, :metro_code, :day, :count])
   end
 
   def upsert(row), do: upsert_all([row])
@@ -29,7 +28,7 @@ defmodule Castle.DailyGeoSubdiv do
     |> Enum.sum()
   end
   def upsert_all(rows) do
-    Castle.Repo.insert_all Castle.DailyGeoSubdiv, rows
+    Castle.Repo.insert_all Castle.DailyGeoMetro, rows
     length(rows)
   end
 end

--- a/lib/castle/daily_geo_subdiv.ex
+++ b/lib/castle/daily_geo_subdiv.ex
@@ -1,0 +1,40 @@
+defmodule Castle.DailyGeoSubdiv do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+
+  schema "daily_geo_subdivs" do
+    field :podcast_id, :integer
+    field :episode_id, :binary_id
+    field :country_iso_code, :string
+    field :subdivision_1_iso_code, :string
+    field :day, :date
+    field :count, :integer
+  end
+
+  @doc false
+  def changeset(download, attrs) do
+    download
+    |> cast(attrs, [:podcast_id, :episode_id, :country_iso_code, :subdivision_1_iso_code, :day, :count])
+    |> validate_required([:podcast_id, :episode_id, :country_iso_code, :subdivision_1_iso_code, :day, :count])
+  end
+
+  def upsert(row), do: upsert_all([row])
+
+  def upsert_all([]), do: 0
+  def upsert_all(rows) when length(rows) > 5000 do
+    Enum.chunk_every(rows, 5000)
+    |> Enum.map(&upsert_all/1)
+    |> Enum.sum()
+  end
+  def upsert_all(rows) do
+    Castle.Repo.insert_all Castle.DailyGeoSubdiv, rows
+    length(rows)
+  end
+
+  # defp parse_row(%{podcast_id: id, episode_guid: guid, hour: hour, count: count}) do
+  #   %{podcast_id: id, episode_id: guid, dtim: hour, count: count}
+  # end
+  # defp parse_row(row), do: row
+end

--- a/lib/castle/hourly_download.ex
+++ b/lib/castle/hourly_download.ex
@@ -27,12 +27,7 @@ defmodule Castle.HourlyDownload do
     |> Enum.sum()
   end
   def upsert_all(rows) do
-    Castle.Repo.insert_all Castle.HourlyDownload, Enum.map(rows, &parse_row/1)
+    Castle.Repo.insert_all Castle.HourlyDownload, rows
     length(rows)
   end
-
-  defp parse_row(%{podcast_id: id, episode_guid: guid, hour: hour, count: count}) do
-    %{podcast_id: id, episode_id: guid, dtim: hour, count: count}
-  end
-  defp parse_row(row), do: row
 end

--- a/lib/castle/monthly_download.ex
+++ b/lib/castle/monthly_download.ex
@@ -1,0 +1,37 @@
+defmodule Castle.MonthlyDownload do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+
+  schema "monthly_downloads" do
+    field :podcast_id, :integer
+    field :episode_id, :binary_id
+    field :month, :date
+    field :count, :integer
+  end
+
+  @doc false
+  def changeset(download, attrs) do
+    download
+    |> cast(attrs, [:podcast_id, :episode_id, :month, :count])
+    |> validate_required([:podcast_id, :episode_id, :month, :count])
+  end
+
+  def upsert!(download) do
+    conflict = [set: [podcast_id: download.podcast_id, count: download.count]]
+    target = [:episode_id, :month]
+    Castle.Repo.insert!(download, on_conflict: conflict, conflict_target: target)
+  end
+
+  def upsert_all!([]), do: 0
+  def upsert_all!(rows) when length(rows) > 5000 do
+    Enum.chunk_every(rows, 5000) |> Enum.map(&upsert_all!/1) |> Enum.sum()
+  end
+  def upsert_all!(rows) do
+    conflict = :replace_all
+    target = [:episode_id, :month]
+    Castle.Repo.insert_all Castle.MonthlyDownload, rows, on_conflict: conflict, conflict_target: target
+    length(rows)
+  end
+end

--- a/lib/castle/monthly_download.ex
+++ b/lib/castle/monthly_download.ex
@@ -24,11 +24,11 @@ defmodule Castle.MonthlyDownload do
     Castle.Repo.insert!(download, on_conflict: conflict, conflict_target: target)
   end
 
-  def upsert_all!([]), do: 0
-  def upsert_all!(rows) when length(rows) > 5000 do
-    Enum.chunk_every(rows, 5000) |> Enum.map(&upsert_all!/1) |> Enum.sum()
+  def upsert_all([]), do: 0
+  def upsert_all(rows) when length(rows) > 5000 do
+    Enum.chunk_every(rows, 5000) |> Enum.map(&upsert_all/1) |> Enum.sum()
   end
-  def upsert_all!(rows) do
+  def upsert_all(rows) do
     conflict = :replace_all
     target = [:episode_id, :month]
     Castle.Repo.insert_all Castle.MonthlyDownload, rows, on_conflict: conflict, conflict_target: target

--- a/lib/castle/rollup_log.ex
+++ b/lib/castle/rollup_log.ex
@@ -2,8 +2,9 @@ defmodule Castle.RollupLog do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @beginning_of_time "2017-04-01"
   @buffer_seconds 300
+  @beginning_of_time ~D[2017-04-01]
+  def beginning_of_time, do: @beginning_of_time
 
   schema "rollup_logs" do
     field :table_name, :string

--- a/lib/castle/rollup_log.ex
+++ b/lib/castle/rollup_log.ex
@@ -2,7 +2,7 @@ defmodule Castle.RollupLog do
   use Ecto.Schema
   import Ecto.Changeset
 
-  @beginning_of_time "2017-04-07"
+  @beginning_of_time "2017-04-01"
   @buffer_seconds 300
 
   schema "rollup_logs" do
@@ -18,15 +18,31 @@ defmodule Castle.RollupLog do
     |> validate_required([:table_name, :date, :complete])
   end
 
-  def upsert(log) do
+  def upsert!(log) do
     conflict = [set: [updated_at: Timex.now(), complete: log.complete]]
     target = [:table_name, :date]
     Castle.Repo.insert!(log, on_conflict: conflict, conflict_target: target)
   end
 
-  def find_missing(table_name, limit, to_date \\ nil) do
+  def find_missing_days(tbl, lim), do: find_missing_days(tbl, lim, default_to_date())
+  def find_missing_days(table_name, limit, to_date) do
+    find_missing table_name, limit, """
+      SELECT r.DATE as date
+      FROM GENERATE_SERIES('#{date_str(to_date)}', '#{@beginning_of_time}', '-1 DAY'::INTERVAL) r
+    """
+  end
+
+  def find_missing_months(tbl, lim), do: find_missing_months(tbl, lim, default_to_date())
+  def find_missing_months(table_name, limit, to_date) do
+    find_missing table_name, limit, """
+      SELECT r.DATE as date
+      FROM GENERATE_SERIES('#{date_str(to_date, :month)}', '#{@beginning_of_time}', '-1 MONTH'::INTERVAL) r
+    """
+  end
+
+  defp find_missing(table_name, limit, range_sql) do
     query = """
-      SELECT range.date FROM (#{select_range(to_date)}) as range
+      SELECT range.date FROM (#{range_sql}) as range
       WHERE range.date NOT IN
         (SELECT date FROM rollup_logs WHERE table_name = $1 AND complete = true)
       ORDER BY range.date DESC limit $2
@@ -35,20 +51,20 @@ defmodule Castle.RollupLog do
     Enum.map result.rows, &(range_to_struct(table_name, hd(&1)))
   end
 
-  defp select_range(nil), do: select_range Timex.shift(Timex.now(), seconds: -@buffer_seconds)
-  defp select_range("" <> to_date_str) do
-    """
-    SELECT r.DATE as date
-    FROM GENERATE_SERIES('#{to_date_str}', '#{@beginning_of_time}', '-1 DAY'::INTERVAL) r
-    """
-  end
-  defp select_range(to_date) do
-    {:ok, date_str} = Timex.format(to_date, "{YYYY}-{0M}-{0D}")
-    select_range(date_str)
-  end
-
   defp range_to_struct(name, erl) do
     {:ok, date} = Date.from_erl(erl)
     %Castle.RollupLog{table_name: name, date: date}
+  end
+
+  defp default_to_date do
+    Timex.now |> Timex.shift(seconds: -@buffer_seconds)
+  end
+
+  defp date_str("" <> date, :month), do: date
+  defp date_str(date, :month), do: Timex.beginning_of_month(date) |> date_str()
+  defp date_str("" <> date), do: date
+  defp date_str(date) do
+    {:ok, date_str} = Timex.format(date, "{YYYY}-{0M}-{0D}")
+    date_str
   end
 end

--- a/lib/rollup/query/monthly_downloads.ex
+++ b/lib/rollup/query/monthly_downloads.ex
@@ -1,0 +1,14 @@
+defmodule Castle.Rollup.Query.MonthlyDownloads do
+  import Ecto.Query
+
+  def all(month) do
+    month = Timex.beginning_of_month(month) |> Timex.to_date
+    month_dtim = Timex.to_datetime(month)
+    next_month = Timex.shift(month_dtim, months: 1)
+    results = Castle.Repo.all from h in Castle.HourlyDownload,
+      where: h.dtim >= ^month_dtim and h.dtim < ^next_month,
+      select: %{podcast_id: h.podcast_id, episode_id: h.episode_id, count: sum(h.count)},
+      group_by: [h.podcast_id, h.episode_id]
+    Enum.map results, &(Map.put(&1, :month, month))
+  end
+end

--- a/lib/rollup/query/monthly_downloads.ex
+++ b/lib/rollup/query/monthly_downloads.ex
@@ -1,7 +1,7 @@
 defmodule Castle.Rollup.Query.MonthlyDownloads do
   import Ecto.Query
 
-  def all(month) do
+  def from_hourly(month) do
     month = Timex.beginning_of_month(month) |> Timex.to_date
     month_dtim = Timex.to_datetime(month)
     next_month = Timex.shift(month_dtim, months: 1)
@@ -10,5 +10,40 @@ defmodule Castle.Rollup.Query.MonthlyDownloads do
       select: %{podcast_id: h.podcast_id, episode_id: h.episode_id, count: sum(h.count)},
       group_by: [h.podcast_id, h.episode_id]
     Enum.map results, &(Map.put(&1, :month, month))
+  end
+
+  def podcast_total_until(podcast_id) do
+    case logs_complete_until() do
+      nil -> {0, default_until()}
+      date ->
+        count = Castle.Repo.one from d in Castle.MonthlyDownload, select: sum(d.count),
+          where: d.podcast_id == ^podcast_id and d.month < ^date
+        {count || 0, date}
+    end
+  end
+
+  def episode_total_until(episode_id) do
+    case logs_complete_until() do
+      nil -> {0, default_until()}
+      date ->
+        count = Castle.Repo.one from d in Castle.MonthlyDownload, select: sum(d.count),
+          where: d.episode_id == ^episode_id and d.month < ^date
+        {count || 0, date}
+    end
+  end
+
+  defp logs_complete_until do
+    log = Castle.Repo.one from l in Castle.RollupLog,
+      where: l.table_name == "monthly_downloads" and l.complete == true,
+      order_by: [desc: :date], limit: 1
+    if log do
+      log.date |> Timex.shift(months: 1) |> Timex.to_date
+    else
+      nil
+    end
+  end
+
+  defp default_until do
+    Castle.RollupLog.beginning_of_time
   end
 end

--- a/lib/rollup/task.ex
+++ b/lib/rollup/task.ex
@@ -1,0 +1,79 @@
+defmodule Castle.Rollup.Task do
+  defmacro __using__(_opts) do
+    quote do
+      use Mix.Task
+      import Castle.Redis.Lock
+      require Logger
+
+      Module.register_attribute __MODULE__, :table, accumulate: false, persist: true
+      Module.register_attribute __MODULE__, :lock, accumulate: false, persist: true
+      Module.register_attribute __MODULE__, :lock_ttl, accumulate: false, persist: true
+      Module.register_attribute __MODULE__, :lock_success_ttl, accumulate: false, persist: true
+      Module.register_attribute __MODULE__, :default_count, accumulate: false, persist: true
+
+      # defaults
+      @table "does_not_exist"
+      @lock "lock.rollup"
+      @lock_ttl 50
+      @lock_success_ttl 200
+      @default_count 5
+
+      def do_rollup(args, work_fn) when is_list(args) do
+        Enum.into(args, %{}) |> do_rollup(work_fn)
+      end
+      def do_rollup(%{lock: true} = args, work_fn) do
+        lock = get_attribute(:lock)
+        lock_ttl = get_attribute(:lock_ttl)
+        success_ttl = get_attribute(:lock_success_ttl)
+        find_rollup_logs(args) |> Enum.map(fn(log) ->
+          lock "#{lock}.#{log.date}", lock_ttl, success_ttl, do: work_fn.(log)
+        end)
+      end
+      def do_rollup(args, work_fn) do
+        find_rollup_logs(args) |> Enum.map(&(work_fn.(&1)))
+      end
+
+      # get attribute from caller module, OR this one
+      def get_attribute(key) do
+        case List.keyfind(__MODULE__.module_info(:attributes), key, 0) do
+          {key, [val]} -> val
+          _ -> nil
+        end
+      end
+
+      defp find_rollup_logs(%{date: date_str}) do
+        [%Castle.RollupLog{table_name: table_name(), date: parse_date(date_str)}]
+      end
+      defp find_rollup_logs(%{count: count}) do
+        Castle.RollupLog.find_missing(table_name(), count)
+      end
+      defp find_rollup_logs(_opts) do
+        Castle.RollupLog.find_missing table_name(), get_attribute(:default_count)
+      end
+
+      defp set_complete(rollup_log) do
+        rollup_log |> Map.put(:complete, true) |> Castle.RollupLog.upsert()
+      end
+
+      defp set_incomplete(rollup_log) do
+        rollup_log |> Map.put(:complete, false) |> Castle.RollupLog.upsert()
+      end
+
+      defp table_name do
+        get_attribute(:table)
+      end
+
+      defp parse_date(str) do
+        format = case String.length(str) do
+          10 -> "{YYYY}-{0M}-{0D}"
+          8 -> "{YYYY}{0M}{0D}"
+          _ -> "{ISO:Extended}"
+        end
+        case Timex.parse(str, format) do
+          {:ok, dtim} -> Timex.to_date(dtim)
+          _ -> raise "Invalid date provided: #{str}"
+        end
+      end
+    end
+  end
+end

--- a/lib/rollup/tasks/geocountries.ex
+++ b/lib/rollup/tasks/geocountries.ex
@@ -1,0 +1,33 @@
+defmodule Mix.Tasks.Castle.Rollup.Geocountries do
+  use Castle.Rollup.Task
+
+  @shortdoc "Rollup bigquery geo iso countries by day"
+
+  @table "daily_geo_countries"
+  @lock "lock.rollup.geocountries"
+
+  def run(args) do
+    {:ok, _started} = Application.ensure_all_started(:castle)
+
+    {opts, _, _} = OptionParser.parse args,
+      switches: [lock: :boolean, date: :string, count: :integer],
+      aliases: [l: :lock, d: :date, c: :count]
+
+    do_rollup(opts, &rollup/1)
+  end
+
+  def rollup(rollup_log) do
+    Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} querying"
+    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.daily_geo_countries()
+    Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} upserting #{length(results)}"
+    Castle.DailyGeoCountry.upsert_all(results)
+    case meta do
+      %{complete: true} ->
+        set_complete(rollup_log)
+        Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} complete"
+      %{complete: false, hours_complete: h} ->
+        set_incomplete(rollup_log)
+        Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} incomplete (#{h}/24 hours)"
+    end
+  end
+end

--- a/lib/rollup/tasks/geometros.ex
+++ b/lib/rollup/tasks/geometros.ex
@@ -1,0 +1,33 @@
+defmodule Mix.Tasks.Castle.Rollup.Geometros do
+  use Castle.Rollup.Task
+
+  @shortdoc "Rollup bigquery geo metro codes by day"
+
+  @table "daily_geo_metros"
+  @lock "lock.rollup.geometros.vrmmm.vrmmmm"
+
+  def run(args) do
+    {:ok, _started} = Application.ensure_all_started(:castle)
+
+    {opts, _, _} = OptionParser.parse args,
+      switches: [lock: :boolean, date: :string, count: :integer],
+      aliases: [l: :lock, d: :date, c: :count]
+
+    do_rollup(opts, &rollup/1)
+  end
+
+  def rollup(rollup_log) do
+    Logger.info "Rollup.DailyGeoMetro.#{rollup_log.date} querying"
+    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.daily_geo_metros()
+    Logger.info "Rollup.DailyGeoMetro.#{rollup_log.date} upserting #{length(results)}"
+    Castle.DailyGeoMetro.upsert_all(results)
+    case meta do
+      %{complete: true} ->
+        set_complete(rollup_log)
+        Logger.info "Rollup.DailyGeoMetro.#{rollup_log.date} complete"
+      %{complete: false, hours_complete: h} ->
+        set_incomplete(rollup_log)
+        Logger.info "Rollup.DailyGeoMetro.#{rollup_log.date} incomplete (#{h}/24 hours)"
+    end
+  end
+end

--- a/lib/rollup/tasks/geosubdiv.ex
+++ b/lib/rollup/tasks/geosubdiv.ex
@@ -1,0 +1,33 @@
+defmodule Mix.Tasks.Castle.Rollup.Geosubdiv do
+  use Castle.Rollup.Task
+
+  @shortdoc "Rollup bigquery geo subdivisions by day"
+
+  @table "daily_geo_subdivs"
+  @lock "lock.rollup.geosubdiv"
+
+  def run(args) do
+    {:ok, _started} = Application.ensure_all_started(:castle)
+
+    {opts, _, _} = OptionParser.parse args,
+      switches: [lock: :boolean, date: :string, count: :integer],
+      aliases: [l: :lock, d: :date, c: :count]
+
+    do_rollup(opts, &rollup/1)
+  end
+
+  def rollup(rollup_log) do
+    Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} querying"
+    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.daily_geo_subdivs()
+    Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} upserting #{length(results)}"
+    Castle.DailyGeoSubdiv.upsert_all(results)
+    case meta do
+      %{complete: true} ->
+        set_complete(rollup_log)
+        Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} complete"
+      %{complete: false, hours_complete: h} ->
+        set_incomplete(rollup_log)
+        Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} incomplete (#{h}/24 hours)"
+    end
+  end
+end

--- a/lib/rollup/tasks/geosubdivs.ex
+++ b/lib/rollup/tasks/geosubdivs.ex
@@ -1,10 +1,10 @@
-defmodule Mix.Tasks.Castle.Rollup.Geosubdiv do
+defmodule Mix.Tasks.Castle.Rollup.Geosubdivs do
   use Castle.Rollup.Task
 
-  @shortdoc "Rollup bigquery geo subdivisions by day"
+  @shortdoc "Rollup bigquery geo iso subdivisions by day"
 
   @table "daily_geo_subdivs"
-  @lock "lock.rollup.geosubdiv"
+  @lock "lock.rollup.geosubdivs"
 
   def run(args) do
     {:ok, _started} = Application.ensure_all_started(:castle)

--- a/lib/rollup/tasks/hourly.ex
+++ b/lib/rollup/tasks/hourly.ex
@@ -1,10 +1,10 @@
-defmodule Mix.Tasks.Castle.Rollup.Downloads do
+defmodule Mix.Tasks.Castle.Rollup.Hourly do
   use Castle.Rollup.Task
 
   @shortdoc "Rollup bigquery downloads by hour"
 
   @table "hourly_downloads"
-  @lock "lock.rollup.downloads"
+  @lock "lock.rollup.hourly_downloads"
 
   def run(args) do
     {:ok, _started} = Application.ensure_all_started(:castle)

--- a/lib/rollup/tasks/monthly.ex
+++ b/lib/rollup/tasks/monthly.ex
@@ -1,0 +1,38 @@
+defmodule Mix.Tasks.Castle.Rollup.Monthly do
+  use Castle.Rollup.Task
+
+  @shortdoc "Rollup bigquery downloads by month"
+
+  @interval "month"
+  @table "monthly_downloads"
+  @lock "lock.rollup.monthly_downloads"
+
+  def run(args) do
+    {:ok, _started} = Application.ensure_all_started(:castle)
+
+    {opts, _, _} = OptionParser.parse args,
+      switches: [lock: :boolean, date: :string, count: :integer],
+      aliases: [l: :lock, d: :date, c: :count]
+
+    do_rollup(opts, &rollup/1)
+  end
+
+  def rollup(rollup_log) do
+    Logger.info "Rollup.MonthlyDownloads.#{rollup_log.date} querying"
+    results = rollup_log.date |> Castle.Rollup.Query.MonthlyDownloads.all()
+    Logger.info "Rollup.MonthlyDownloads.#{rollup_log.date} upserting #{length(results)}"
+    Castle.MonthlyDownload.upsert_all(results)
+    if is_past_month?(rollup_log.date) do
+      set_complete(rollup_log)
+      Logger.info "Rollup.MonthlyDownloads.#{rollup_log.date} complete"
+    else
+      set_incomplete(rollup_log)
+      Logger.info "Rollup.MonthlyDownloads.#{rollup_log.date} incomplete"
+    end
+  end
+
+  def is_past_month?(date, now \\ Timex.now) do
+    offset = Timex.shift(now, months: -1, days: -1)
+    Timex.compare(offset, date) > -1
+  end
+end

--- a/lib/rollup/tasks/monthly.ex
+++ b/lib/rollup/tasks/monthly.ex
@@ -6,6 +6,7 @@ defmodule Mix.Tasks.Castle.Rollup.Monthly do
   @interval "month"
   @table "monthly_downloads"
   @lock "lock.rollup.monthly_downloads"
+  @default_count 10
 
   def run(args) do
     {:ok, _started} = Application.ensure_all_started(:castle)

--- a/lib/rollup/tasks/monthly.ex
+++ b/lib/rollup/tasks/monthly.ex
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Castle.Rollup.Monthly do
 
   def rollup(rollup_log) do
     Logger.info "Rollup.MonthlyDownloads.#{rollup_log.date} querying"
-    results = rollup_log.date |> Castle.Rollup.Query.MonthlyDownloads.all()
+    results = rollup_log.date |> Castle.Rollup.Query.MonthlyDownloads.from_hourly()
     Logger.info "Rollup.MonthlyDownloads.#{rollup_log.date} upserting #{length(results)}"
     Castle.MonthlyDownload.upsert_all(results)
     if is_past_month?(rollup_log.date) do

--- a/priv/repo/migrations/20180522192356_add_rollup_logs_complete.exs
+++ b/priv/repo/migrations/20180522192356_add_rollup_logs_complete.exs
@@ -1,0 +1,10 @@
+defmodule Castle.Repo.Migrations.AddRollupLogsComplete do
+  use Ecto.Migration
+
+  def change do
+    alter table(:rollup_logs) do
+      add :complete, :boolean, default: false
+    end
+    execute "UPDATE rollup_logs SET complete = true"
+  end
+end

--- a/priv/repo/migrations/20180522223601_create_daily_geo_subdivs.exs
+++ b/priv/repo/migrations/20180522223601_create_daily_geo_subdivs.exs
@@ -1,0 +1,58 @@
+defmodule Castle.Repo.Migrations.CreateDailyGeoSubdivs do
+  use Ecto.Migration
+
+  def change do
+    create table(:daily_geo_subdivs, primary_key: false) do
+      add :podcast_id, :integer, null: false
+      add :episode_id, :uuid, null: false
+      add :country_iso_code, :string, null: false
+      add :subdivision_1_iso_code, :string, null: false
+      add :day, :date, null: false
+      add :count, :integer, null: false
+    end
+
+    execute """
+    CREATE OR REPLACE FUNCTION create_daily_geo_subdivs_partition() RETURNS trigger AS
+    $$
+      DECLARE
+        partition_start DATE;
+        partition_end DATE;
+        partition TEXT;
+      BEGIN
+        partition_start := DATE_TRUNC('MONTH', NEW.day);
+        partition_end := partition_start + INTERVAL '1 MONTH';
+        partition := 'daily_geo_subdivs_' || to_char(NEW.day,'YYYYMM');
+        IF NOT EXISTS(SELECT relname FROM pg_class WHERE relname=partition) THEN
+          RAISE NOTICE 'A partition has been created %',partition;
+          EXECUTE 'CREATE TABLE ' || partition || ' (CHECK (day >= DATE ''' || partition_start || ''' AND day < DATE ''' || partition_end || '''), CONSTRAINT ' || partition || '_uniq UNIQUE (episode_id, country_iso_code, subdivision_1_iso_code, day)) INHERITS (daily_geo_subdivs);';
+          EXECUTE 'CREATE INDEX ' || partition || '_podcast_id_index ON ' || partition || ' (podcast_id);';
+          EXECUTE 'CREATE INDEX ' || partition || '_episode_id_index ON ' || partition || ' (episode_id);';
+          EXECUTE 'CREATE INDEX ' || partition || '_day_index ON ' || partition || ' (day);';
+        END IF;
+        EXECUTE 'INSERT INTO ' || partition || ' SELECT(daily_geo_subdivs ' || quote_literal(NEW) || ').* ON CONFLICT ON CONSTRAINT ' || partition || '_uniq DO UPDATE SET (podcast_id, count) = (' || NEW.podcast_id || ', ' || NEW.count || ');';
+        RETURN NULL;
+      END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER daily_geo_subdivs_partition_insert_trigger
+    BEFORE INSERT ON daily_geo_subdivs
+    FOR EACH ROW EXECUTE PROCEDURE create_daily_geo_subdivs_partition();
+    """
+  end
+
+  def down do
+    Enum.map inherited_tables(), fn(table_name) ->
+      drop table(table_name)
+    end
+    drop table(:daily_geo_subdivs)
+    execute "DROP FUNCTION create_daily_geo_subdivs_partition()"
+  end
+
+  defp inherited_tables do
+    query = "select tablename from pg_tables where tablename like 'daily_geo_subdivs\_______'"
+    result = Ecto.Adapters.SQL.query!(Castle.Repo, query, [])
+    List.flatten(result.rows)
+  end
+end

--- a/priv/repo/migrations/20180523195202_create_daily_geo_countries.exs
+++ b/priv/repo/migrations/20180523195202_create_daily_geo_countries.exs
@@ -1,0 +1,57 @@
+defmodule Castle.Repo.Migrations.CreateDailyGeoCountries do
+  use Ecto.Migration
+
+  def change do
+    create table(:daily_geo_countries, primary_key: false) do
+      add :podcast_id, :integer, null: false
+      add :episode_id, :uuid, null: false
+      add :country_iso_code, :string, null: false
+      add :day, :date, null: false
+      add :count, :integer, null: false
+    end
+
+    execute """
+    CREATE OR REPLACE FUNCTION create_daily_geo_countries_partition() RETURNS trigger AS
+    $$
+      DECLARE
+        partition_start DATE;
+        partition_end DATE;
+        partition TEXT;
+      BEGIN
+        partition_start := DATE_TRUNC('MONTH', NEW.day);
+        partition_end := partition_start + INTERVAL '1 MONTH';
+        partition := 'daily_geo_countries_' || to_char(NEW.day,'YYYYMM');
+        IF NOT EXISTS(SELECT relname FROM pg_class WHERE relname=partition) THEN
+          RAISE NOTICE 'A partition has been created %',partition;
+          EXECUTE 'CREATE TABLE ' || partition || ' (CHECK (day >= DATE ''' || partition_start || ''' AND day < DATE ''' || partition_end || '''), CONSTRAINT ' || partition || '_uniq UNIQUE (episode_id, country_iso_code, day)) INHERITS (daily_geo_countries);';
+          EXECUTE 'CREATE INDEX ' || partition || '_podcast_id_index ON ' || partition || ' (podcast_id);';
+          EXECUTE 'CREATE INDEX ' || partition || '_episode_id_index ON ' || partition || ' (episode_id);';
+          EXECUTE 'CREATE INDEX ' || partition || '_day_index ON ' || partition || ' (day);';
+        END IF;
+        EXECUTE 'INSERT INTO ' || partition || ' SELECT(daily_geo_countries ' || quote_literal(NEW) || ').* ON CONFLICT ON CONSTRAINT ' || partition || '_uniq DO UPDATE SET (podcast_id, count) = (' || NEW.podcast_id || ', ' || NEW.count || ');';
+        RETURN NULL;
+      END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER daily_geo_countries_partition_insert_trigger
+    BEFORE INSERT ON daily_geo_countries
+    FOR EACH ROW EXECUTE PROCEDURE create_daily_geo_countries_partition();
+    """
+  end
+
+  def down do
+    Enum.map inherited_tables(), fn(table_name) ->
+      drop table(table_name)
+    end
+    drop table(:daily_geo_countries)
+    execute "DROP FUNCTION create_daily_geo_countries_partition()"
+  end
+
+  defp inherited_tables do
+    query = "select tablename from pg_tables where tablename like 'daily_geo_countries\_______'"
+    result = Ecto.Adapters.SQL.query!(Castle.Repo, query, [])
+    List.flatten(result.rows)
+  end
+end

--- a/priv/repo/migrations/20180523195208_create_daily_geo_metros.exs
+++ b/priv/repo/migrations/20180523195208_create_daily_geo_metros.exs
@@ -1,0 +1,57 @@
+defmodule Castle.Repo.Migrations.CreateDailyGeoMetros do
+  use Ecto.Migration
+
+  def change do
+    create table(:daily_geo_metros, primary_key: false) do
+      add :podcast_id, :integer, null: false
+      add :episode_id, :uuid, null: false
+      add :metro_code, :integer, null: false
+      add :day, :date, null: false
+      add :count, :integer, null: false
+    end
+
+    execute """
+    CREATE OR REPLACE FUNCTION create_daily_geo_metros_partition() RETURNS trigger AS
+    $$
+      DECLARE
+        partition_start DATE;
+        partition_end DATE;
+        partition TEXT;
+      BEGIN
+        partition_start := DATE_TRUNC('MONTH', NEW.day);
+        partition_end := partition_start + INTERVAL '1 MONTH';
+        partition := 'daily_geo_metros_' || to_char(NEW.day,'YYYYMM');
+        IF NOT EXISTS(SELECT relname FROM pg_class WHERE relname=partition) THEN
+          RAISE NOTICE 'A partition has been created %',partition;
+          EXECUTE 'CREATE TABLE ' || partition || ' (CHECK (day >= DATE ''' || partition_start || ''' AND day < DATE ''' || partition_end || '''), CONSTRAINT ' || partition || '_uniq UNIQUE (episode_id, metro_code, day)) INHERITS (daily_geo_metros);';
+          EXECUTE 'CREATE INDEX ' || partition || '_podcast_id_index ON ' || partition || ' (podcast_id);';
+          EXECUTE 'CREATE INDEX ' || partition || '_episode_id_index ON ' || partition || ' (episode_id);';
+          EXECUTE 'CREATE INDEX ' || partition || '_day_index ON ' || partition || ' (day);';
+        END IF;
+        EXECUTE 'INSERT INTO ' || partition || ' SELECT(daily_geo_metros ' || quote_literal(NEW) || ').* ON CONFLICT ON CONSTRAINT ' || partition || '_uniq DO UPDATE SET (podcast_id, count) = (' || NEW.podcast_id || ', ' || NEW.count || ');';
+        RETURN NULL;
+      END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER daily_geo_metros_partition_insert_trigger
+    BEFORE INSERT ON daily_geo_metros
+    FOR EACH ROW EXECUTE PROCEDURE create_daily_geo_metros_partition();
+    """
+  end
+
+  def down do
+    Enum.map inherited_tables(), fn(table_name) ->
+      drop table(table_name)
+    end
+    drop table(:daily_geo_metros)
+    execute "DROP FUNCTION create_daily_geo_metros_partition()"
+  end
+
+  defp inherited_tables do
+    query = "select tablename from pg_tables where tablename like 'daily_geo_metros\_______'"
+    result = Ecto.Adapters.SQL.query!(Castle.Repo, query, [])
+    List.flatten(result.rows)
+  end
+end

--- a/priv/repo/migrations/20180524211355_create_monthly_downloads.exs
+++ b/priv/repo/migrations/20180524211355_create_monthly_downloads.exs
@@ -1,0 +1,14 @@
+defmodule Castle.Repo.Migrations.CreateMonthlyDownloads do
+  use Ecto.Migration
+
+  def change do
+    create table(:monthly_downloads, primary_key: false) do
+      add :podcast_id, :integer, null: false
+      add :episode_id, :uuid, null: false
+      add :month, :date, null: false
+      add :count, :integer, null: false
+    end
+    create unique_index(:monthly_downloads, [:episode_id, :month])
+    create constraint(:monthly_downloads, :monthly_downloads_date, check: "EXTRACT(DAY from month) = 1")
+  end
+end

--- a/scripts/load_geonames.rb
+++ b/scripts/load_geonames.rb
@@ -86,7 +86,8 @@ end
 print '  creating '
 table = dataset.create_table 'geonames' do |schema|
   schema.integer 'geoname_id', mode: :required
-  (FIELDS - ['geoname_id']).each do |name|
+  schema.integer 'metro_code'
+  (FIELDS - ['geoname_id', 'metro_code']).each do |name|
     schema.string name
   end
 end

--- a/test/big_query/rollup/daily_geo_countries_test.exs
+++ b/test/big_query/rollup/daily_geo_countries_test.exs
@@ -1,16 +1,16 @@
-defmodule Castle.BigQueryRollupHourlyDownloadsTest do
+defmodule Castle.BigQueryRollupDailyGeoCountriesTest do
   use Castle.BigQueryCase
 
-  import BigQuery.Rollup.HourlyDownloads
+  import BigQuery.Rollup.DailyGeoCountries
 
-  test_with_bq "gets empty hourly downloads in the past", [] do
+  test_with_bq "gets empty geo countries in the past", [] do
     {results, meta} = query(get_dtim("2016-01-01T05:04:00Z"))
     assert length(results) == 0
     assert_time meta.day, "2016-01-01T00:00:00Z"
     assert meta.complete == true
   end
 
-  test "gets empty hourly downloads in the future" do
+  test "gets empty geo countries in the future" do
     {results, meta} = query(get_dtim("2030-01-01"))
     assert length(results) == 0
     assert_time meta.day, "2030-01-01T00:00:00Z"
@@ -18,10 +18,10 @@ defmodule Castle.BigQueryRollupHourlyDownloadsTest do
     assert meta.hours_complete == 0
   end
 
-  test_with_bq "gets a partial day of downloads", "2017-05-01T05:14:37Z", [
-    %{podcast_id: 1, episode_id: "a", hour: 2, count: 123},
-    %{podcast_id: 2, episode_id: "b", hour: 6, count: 456},
-    %{podcast_id: 1, episode_id: "a", hour: 1, count: 789},
+  test_with_bq "gets a partial day of geo countries", "2017-05-01T05:14:37Z", [
+    %{podcast_id: 1, episode_id: "a", country_iso_code: "US", count: 123},
+    %{podcast_id: 2, episode_id: "b", country_iso_code: "US", count: 456},
+    %{podcast_id: 1, episode_id: "a", country_iso_code: "US", count: 789},
   ] do
     {results, meta} = query(get_dtim("2017-05-01"))
     assert length(results) == 3
@@ -30,18 +30,17 @@ defmodule Castle.BigQueryRollupHourlyDownloadsTest do
     assert meta.hours_complete == 4
     assert hd(results).podcast_id == 1
     assert hd(results).episode_id == "a"
+    assert hd(results).country_iso_code == "US"
     assert hd(results).count == 123
-    assert_time Enum.at(results, 0).dtim, "2017-05-01T02:00:00Z"
-    assert_time Enum.at(results, 1).dtim, "2017-05-01T06:00:00Z"
-    assert_time Enum.at(results, 2).dtim, "2017-05-01T01:00:00Z"
+    assert hd(results).day == ~D[2017-05-01]
   end
 
   @tag :external
   test "actually gets data" do
     {results, meta} = query(get_dtim("2017-05-01"))
-    assert length(results) == 24248
+    assert length(results) == 20762
     assert_time meta.day, "2017-05-01T00:00:00Z"
     assert meta.complete == true
-    assert format_dtim(hd(results).dtim) =~ ~r/2017-05-01T[0-2][0-9]:00:00/
+    assert hd(results).day == ~D[2017-05-01]
   end
 end

--- a/test/big_query/rollup/daily_geo_metros_test.exs
+++ b/test/big_query/rollup/daily_geo_metros_test.exs
@@ -1,16 +1,16 @@
-defmodule Castle.BigQueryRollupHourlyDownloadsTest do
+defmodule Castle.BigQueryRollupDailyGeoMetrosTest do
   use Castle.BigQueryCase
 
-  import BigQuery.Rollup.HourlyDownloads
+  import BigQuery.Rollup.DailyGeoMetros
 
-  test_with_bq "gets empty hourly downloads in the past", [] do
+  test_with_bq "gets empty geo metros in the past", [] do
     {results, meta} = query(get_dtim("2016-01-01T05:04:00Z"))
     assert length(results) == 0
     assert_time meta.day, "2016-01-01T00:00:00Z"
     assert meta.complete == true
   end
 
-  test "gets empty hourly downloads in the future" do
+  test "gets empty geo metros in the future" do
     {results, meta} = query(get_dtim("2030-01-01"))
     assert length(results) == 0
     assert_time meta.day, "2030-01-01T00:00:00Z"
@@ -18,10 +18,10 @@ defmodule Castle.BigQueryRollupHourlyDownloadsTest do
     assert meta.hours_complete == 0
   end
 
-  test_with_bq "gets a partial day of downloads", "2017-05-01T05:14:37Z", [
-    %{podcast_id: 1, episode_id: "a", hour: 2, count: 123},
-    %{podcast_id: 2, episode_id: "b", hour: 6, count: 456},
-    %{podcast_id: 1, episode_id: "a", hour: 1, count: 789},
+  test_with_bq "gets a partial day of geo metros", "2017-05-01T05:14:37Z", [
+    %{podcast_id: 1, episode_id: "a", metro_code: 9999, count: 123},
+    %{podcast_id: 2, episode_id: "b", metro_code: 8888, count: 456},
+    %{podcast_id: 1, episode_id: "a", metro_code: 7777, count: 789},
   ] do
     {results, meta} = query(get_dtim("2017-05-01"))
     assert length(results) == 3
@@ -30,18 +30,18 @@ defmodule Castle.BigQueryRollupHourlyDownloadsTest do
     assert meta.hours_complete == 4
     assert hd(results).podcast_id == 1
     assert hd(results).episode_id == "a"
+    assert hd(results).metro_code == 9999
     assert hd(results).count == 123
-    assert_time Enum.at(results, 0).dtim, "2017-05-01T02:00:00Z"
-    assert_time Enum.at(results, 1).dtim, "2017-05-01T06:00:00Z"
-    assert_time Enum.at(results, 2).dtim, "2017-05-01T01:00:00Z"
+    assert hd(results).day == ~D[2017-05-01]
   end
 
   @tag :external
   test "actually gets data" do
     {results, meta} = query(get_dtim("2017-05-01"))
-    assert length(results) == 24248
+    assert length(results) == 48440
     assert_time meta.day, "2017-05-01T00:00:00Z"
     assert meta.complete == true
-    assert format_dtim(hd(results).dtim) =~ ~r/2017-05-01T[0-2][0-9]:00:00/
+    assert hd(results).day == ~D[2017-05-01]
+    assert hd(results).metro_code > 0
   end
 end

--- a/test/big_query/rollup/hourly_downloads_test.exs
+++ b/test/big_query/rollup/hourly_downloads_test.exs
@@ -1,0 +1,39 @@
+defmodule Castle.BigQueryRollupHourlyDownloadsTest do
+  use Castle.BigQueryCase, async: false
+  use Castle.TimeHelpers
+
+  import BigQuery.Rollup.HourlyDownloads
+  import Mock
+
+  @tag :external
+  test "gets empty hourly downloads in the past" do
+    {results, meta} = query(get_dtim("2016-01-01T05:04:00Z"))
+    assert length(results) == 0
+    assert_time meta.day, "2016-01-01T00:00:00Z"
+    assert meta.complete == true
+  end
+
+  test "gets empty hourly downloads in the future" do
+    {results, meta} = query(get_dtim("2030-01-01"))
+    assert length(results) == 0
+    assert_time meta.day, "2030-01-01T00:00:00Z"
+    assert meta.complete == false
+    assert meta.hours_complete == 0
+  end
+
+  @tag :external
+  test "gets a partial day of downloads" do
+    with_mock Timex, [:passthrough], [now: fn() -> get_dtim("2017-05-01T05:14:37Z") end] do
+      {results, meta} = query(get_dtim("2017-05-01"))
+      assert length(results) == 24248 # known
+      assert_time meta.day, "2017-05-01T00:00:00Z"
+      assert meta.complete == false
+      assert meta.hours_complete == 4
+
+      assert format_dtim(hd(results).dtim) =~ ~r/2017-05-01T[0-2][0-9]:00:00/
+      assert is_binary hd(results).episode_id
+      assert is_number hd(results).podcast_id
+      assert hd(results).count > 0
+    end
+  end
+end

--- a/test/big_query/rollup_test.exs
+++ b/test/big_query/rollup_test.exs
@@ -1,9 +1,7 @@
 defmodule Castle.BigQueryRollupTest do
-  use Castle.BigQueryCase, async: false
-  use Castle.TimeHelpers
+  use Castle.BigQueryCase
 
   import BigQuery.Rollup
-  import Mock
 
   test "gets nothing for future days" do
     {results, meta} = for_day get_dtim("2030-01-01"), fn(_) -> ["nothing"] end
@@ -13,25 +11,21 @@ defmodule Castle.BigQueryRollupTest do
     assert meta.hours_complete == 0
   end
 
-  test "gets partial for today" do
-    with_mock Timex, [:passthrough], [now: fn() -> get_dtim("2017-05-01T15:14:13Z") end] do
-      {results, meta} = for_day Timex.now, fn(_) -> {["something"], %{meta: "data"}} end
-      assert length(results) == 1
-      assert results == ["something"]
-      assert_time Timex.to_date(meta.day), "2017-05-01T00:00:00Z"
-      assert meta.complete == false
-      assert meta.hours_complete == 14
-    end
+  test_with_bq "gets partial for today", "2017-05-01T15:14:13Z", [] do
+    {results, meta} = for_day Timex.now, fn(_) -> {["something"], %{meta: "data"}} end
+    assert length(results) == 1
+    assert results == ["something"]
+    assert_time Timex.to_date(meta.day), "2017-05-01T00:00:00Z"
+    assert meta.complete == false
+    assert meta.hours_complete == 14
   end
 
-  test "gets complete for the past" do
-    with_mock Timex, [:passthrough], [now: fn() -> get_dtim("2017-05-01T15:14:13Z") end] do
-      {results, meta} = for_day get_dtim("2017-04-29"), fn(_) -> {["something"], %{meta: "data"}} end
-      assert length(results) == 1
-      assert results == ["something"]
-      assert_time Timex.to_date(meta.day), "2017-04-29T00:00:00Z"
-      assert meta.complete == true
-    end
+  test_with_bq "gets complete for the past", "2017-05-01T15:14:13Z", [] do
+    {results, meta} = for_day get_dtim("2017-04-29"), fn(_) -> {["something"], %{meta: "data"}} end
+    assert length(results) == 1
+    assert results == ["something"]
+    assert_time Timex.to_date(meta.day), "2017-04-29T00:00:00Z"
+    assert meta.complete == true
   end
 
   test "does not indicate a day is complete until 15 minutes after" do

--- a/test/big_query/rollup_test.exs
+++ b/test/big_query/rollup_test.exs
@@ -5,35 +5,32 @@ defmodule Castle.BigQueryRollupTest do
   import BigQuery.Rollup
   import Mock
 
-  @tag :external
-  test "gets empty hourly downloads in the past" do
-    {results, meta} = hourly_downloads(get_dtim("2016-01-01T05:04:00Z"))
-    assert length(results) == 0
-    assert_time meta.day, "2016-01-01T00:00:00Z"
-    assert meta.complete == true
-  end
-
-  test "gets empty hourly downloads in the future" do
-    {results, meta} = hourly_downloads(get_dtim("2030-01-01"))
+  test "gets nothing for future days" do
+    {results, meta} = for_day get_dtim("2030-01-01"), fn(_) -> ["nothing"] end
     assert length(results) == 0
     assert_time meta.day, "2030-01-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 0
   end
 
-  @tag :external
-  test "gets a partial day of downloads" do
-    with_mock Timex, [:passthrough], [now: fn() -> get_dtim("2017-05-01T05:14:37Z") end] do
-      {results, meta} = hourly_downloads(get_dtim("2017-05-01"))
-      assert length(results) == 24248 # known
-      assert_time meta.day, "2017-05-01T00:00:00Z"
+  test "gets partial for today" do
+    with_mock Timex, [:passthrough], [now: fn() -> get_dtim("2017-05-01T15:14:13Z") end] do
+      {results, meta} = for_day Timex.now, fn(_) -> {["something"], %{meta: "data"}} end
+      assert length(results) == 1
+      assert results == ["something"]
+      assert_time Timex.to_date(meta.day), "2017-05-01T00:00:00Z"
       assert meta.complete == false
-      assert meta.hours_complete == 4
+      assert meta.hours_complete == 14
+    end
+  end
 
-      assert format_dtim(hd(results).hour) =~ ~r/2017-05-01T[0-2][0-9]:00:00/
-      assert is_binary hd(results).episode_guid
-      assert is_number hd(results).podcast_id
-      assert hd(results).count > 0
+  test "gets complete for the past" do
+    with_mock Timex, [:passthrough], [now: fn() -> get_dtim("2017-05-01T15:14:13Z") end] do
+      {results, meta} = for_day get_dtim("2017-04-29"), fn(_) -> {["something"], %{meta: "data"}} end
+      assert length(results) == 1
+      assert results == ["something"]
+      assert_time Timex.to_date(meta.day), "2017-04-29T00:00:00Z"
+      assert meta.complete == true
     end
   end
 

--- a/test/castle/hourly_download_test.exs
+++ b/test/castle/hourly_download_test.exs
@@ -35,7 +35,7 @@ defmodule Castle.HourlyDownloadTest do
   defp do_upsert_all(dtim, count), do: do_upsert_all([{dtim, count}])
   defp do_upsert_all(rows) when is_list(rows) do
     rows
-      |> Enum.map(fn({dtim, count}) -> %{podcast_id: @id, episode_guid: @guid, hour: get_dtim(dtim), count: count} end)
+      |> Enum.map(fn({dtim, count}) -> %{podcast_id: @id, episode_id: @guid, dtim: get_dtim(dtim), count: count} end)
       |> upsert_all()
   end
 

--- a/test/castle/monthly_download_test.exs
+++ b/test/castle/monthly_download_test.exs
@@ -1,0 +1,21 @@
+defmodule Castle.MonthlyDownloadTest do
+  use Castle.DataCase, async: true
+
+  import Castle.MonthlyDownload
+
+  @id 1234
+  @guid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+  test "upserts all" do
+    upsert_all! [
+      %{podcast_id: @id, episode_id: @guid, month: ~D[2018-01-01], count: 10},
+      %{podcast_id: @id, episode_id: @guid, month: ~D[2018-02-01], count: 11},
+      %{podcast_id: @id, episode_id: @guid, month: ~D[2018-03-01], count: 12}
+    ]
+    downs = Repo.all(from d in Castle.MonthlyDownload)
+    assert length(downs) == 3
+    assert Enum.at(downs, 0).count == 10
+    assert Enum.at(downs, 1).count == 11
+    assert Enum.at(downs, 2).count == 12
+  end
+end

--- a/test/castle/monthly_download_test.exs
+++ b/test/castle/monthly_download_test.exs
@@ -7,7 +7,7 @@ defmodule Castle.MonthlyDownloadTest do
   @guid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
   test "upserts all" do
-    upsert_all! [
+    upsert_all [
       %{podcast_id: @id, episode_id: @guid, month: ~D[2018-01-01], count: 10},
       %{podcast_id: @id, episode_id: @guid, month: ~D[2018-02-01], count: 11},
       %{podcast_id: @id, episode_id: @guid, month: ~D[2018-03-01], count: 12}

--- a/test/castle/rollup_log_test.exs
+++ b/test/castle/rollup_log_test.exs
@@ -25,6 +25,15 @@ defmodule Castle.RollupLogTest do
     assert "#{Enum.at(result, 3).date}" == "2018-04-20"
   end
 
+  test "ignores incomplete logs" do
+    upsert build_log("foobar", 2018, 4, 24)
+    upsert build_log("foobar2", 2018, 4, 23, false)
+    result = find_missing("foobar", 2, "2018-04-25")
+    assert length(result) == 2
+    assert "#{Enum.at(result, 0).date}" == "2018-04-25"
+    assert "#{Enum.at(result, 1).date}" == "2018-04-23"
+  end
+
   test "finds empty range" do
     result = find_missing("foobar", 100, "1995-01-01")
     assert length(result) == 0
@@ -62,7 +71,7 @@ defmodule Castle.RollupLogTest do
     assert Timex.diff(final.updated_at, log2.updated_at, :seconds) == 0
   end
 
-  defp build_log(name, year, month, day) do
-    %Castle.RollupLog{table_name: name, date: Ecto.Date.from_erl({year, month, day})}
+  defp build_log(name, year, month, day, complete \\ true) do
+    %Castle.RollupLog{table_name: name, date: Ecto.Date.from_erl({year, month, day}), complete: complete}
   end
 end

--- a/test/rollup/query/monthly_downloads.exs
+++ b/test/rollup/query/monthly_downloads.exs
@@ -1,0 +1,51 @@
+defmodule Castle.RollupMonthlyDownloadsTest do
+  use Castle.DataCase
+  use Castle.TimeHelpers
+
+  alias Castle.Rollup.Query.MonthlyDownloads, as: MonthlyDownloads
+
+  @id1 1234
+  @id2 5678
+  @guid1 "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+  @guid2 "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+  @guid3 "cccccccc-cccc-cccc-cccc-cccccccccccc"
+
+  setup do
+    now = get_dtim("2018-04-24T13:22:09")
+    do_insert(@id1, @guid1, "2018-05-01T14:00:00", 1)
+    do_insert(@id1, @guid1, "2018-04-24T13:00:00", 2)
+    do_insert(@id1, @guid1, "2018-04-24T01:00:00", 3)
+    do_insert(@id1, @guid1, "2018-04-23T22:00:00", 4)
+    do_insert(@id1, @guid2, "2018-04-22T09:00:00", 5)
+    do_insert(@id2, @guid3, "2018-04-17T08:00:00", 6)
+    do_insert(@id1, @guid1, "2018-04-11T08:00:00", 7)
+    do_insert(@id1, @guid1, "2018-03-29T08:00:00", 8)
+    [now: now]
+  end
+
+  test "gets an entire month of data", %{now: now} do
+    month = MonthlyDownloads.all(now)
+    assert length(month) == 3
+    assert Enum.at(month, 0).podcast_id == @id1
+    assert Enum.at(month, 0).episode_id == @guid1
+    assert Enum.at(month, 0).count == 16
+    assert Enum.at(month, 0).month == ~D[2018-04-01]
+    assert Enum.at(month, 1).podcast_id == @id1
+    assert Enum.at(month, 1).episode_id == @guid2
+    assert Enum.at(month, 1).count == 5
+    assert Enum.at(month, 1).month == ~D[2018-04-01]
+    assert Enum.at(month, 2).podcast_id == @id2
+    assert Enum.at(month, 2).episode_id == @guid3
+    assert Enum.at(month, 2).count == 6
+    assert Enum.at(month, 2).month == ~D[2018-04-01]
+  end
+
+  defp do_insert(id, guid, dtim_str, count) do
+    Castle.HourlyDownload.upsert %{
+      podcast_id: id,
+      episode_id: guid,
+      dtim: get_dtim(dtim_str),
+      count: count
+    }
+  end
+end

--- a/test/rollup/query/monthly_downloads.exs
+++ b/test/rollup/query/monthly_downloads.exs
@@ -2,7 +2,7 @@ defmodule Castle.RollupMonthlyDownloadsTest do
   use Castle.DataCase
   use Castle.TimeHelpers
 
-  alias Castle.Rollup.Query.MonthlyDownloads, as: MonthlyDownloads
+  import Castle.Rollup.Query.MonthlyDownloads
 
   @id1 1234
   @id2 5678
@@ -12,19 +12,19 @@ defmodule Castle.RollupMonthlyDownloadsTest do
 
   setup do
     now = get_dtim("2018-04-24T13:22:09")
-    do_insert(@id1, @guid1, "2018-05-01T14:00:00", 1)
-    do_insert(@id1, @guid1, "2018-04-24T13:00:00", 2)
-    do_insert(@id1, @guid1, "2018-04-24T01:00:00", 3)
-    do_insert(@id1, @guid1, "2018-04-23T22:00:00", 4)
-    do_insert(@id1, @guid2, "2018-04-22T09:00:00", 5)
-    do_insert(@id2, @guid3, "2018-04-17T08:00:00", 6)
-    do_insert(@id1, @guid1, "2018-04-11T08:00:00", 7)
-    do_insert(@id1, @guid1, "2018-03-29T08:00:00", 8)
+    upsert_hourly(@id1, @guid1, "2018-05-01T14:00:00", 1)
+    upsert_hourly(@id1, @guid1, "2018-04-24T13:00:00", 2)
+    upsert_hourly(@id1, @guid1, "2018-04-24T01:00:00", 3)
+    upsert_hourly(@id1, @guid1, "2018-04-23T22:00:00", 4)
+    upsert_hourly(@id1, @guid2, "2018-04-22T09:00:00", 5)
+    upsert_hourly(@id2, @guid3, "2018-04-17T08:00:00", 6)
+    upsert_hourly(@id1, @guid1, "2018-04-11T08:00:00", 7)
+    upsert_hourly(@id1, @guid1, "2018-03-29T08:00:00", 8)
     [now: now]
   end
 
   test "gets an entire month of data", %{now: now} do
-    month = MonthlyDownloads.all(now)
+    month = from_hourly(now)
     assert length(month) == 3
     assert Enum.at(month, 0).podcast_id == @id1
     assert Enum.at(month, 0).episode_id == @guid1
@@ -40,12 +40,58 @@ defmodule Castle.RollupMonthlyDownloadsTest do
     assert Enum.at(month, 2).month == ~D[2018-04-01]
   end
 
-  defp do_insert(id, guid, dtim_str, count) do
+  test "gets podcast totals until a date" do
+    beginning = Castle.RollupLog.beginning_of_time
+    upsert_monthly(@id1, @guid1, ~D[2018-01-01], 10)
+    upsert_monthly(@id1, @guid1, ~D[2018-04-01], 11)
+
+    assert podcast_total_until(@id1) == {0, beginning}
+    assert podcast_total_until(@id2) == {0, beginning}
+    upsert_log(~D[2018-01-01], false)
+    assert podcast_total_until(@id1) == {0, beginning}
+    assert podcast_total_until(@id2) == {0, beginning}
+    upsert_log(~D[2018-01-01], true)
+    assert podcast_total_until(@id1) == {10, ~D[2018-02-01]}
+    assert podcast_total_until(@id2) == {0, ~D[2018-02-01]}
+    upsert_log(~D[2018-04-01], true)
+    assert podcast_total_until(@id1) == {21, ~D[2018-05-01]}
+    assert podcast_total_until(@id2) == {0, ~D[2018-05-01]}
+  end
+
+  test "gets episode totals until a date" do
+    beginning = Castle.RollupLog.beginning_of_time
+    upsert_monthly(@id1, @guid1, ~D[2018-01-01], 10)
+    upsert_monthly(@id1, @guid1, ~D[2018-04-01], 11)
+
+    assert episode_total_until(@guid1) == {0, beginning}
+    assert episode_total_until(@guid2) == {0, beginning}
+    upsert_log(~D[2018-01-01], false)
+    assert episode_total_until(@guid1) == {0, beginning}
+    assert episode_total_until(@guid2) == {0, beginning}
+    upsert_log(~D[2018-01-01], true)
+    assert episode_total_until(@guid1) == {10, ~D[2018-02-01]}
+    assert episode_total_until(@guid2) == {0, ~D[2018-02-01]}
+    upsert_log(~D[2018-04-01], true)
+    assert episode_total_until(@guid1) == {21, ~D[2018-05-01]}
+    assert episode_total_until(@guid2) == {0, ~D[2018-05-01]}
+  end
+
+  defp upsert_hourly(id, guid, dtim_str, count) do
     Castle.HourlyDownload.upsert %{
       podcast_id: id,
       episode_id: guid,
       dtim: get_dtim(dtim_str),
       count: count
     }
+  end
+
+  defp upsert_monthly(id, guid, date, count) do
+    [%{podcast_id: id, episode_id: guid, month: date, count: count}]
+    |> Castle.MonthlyDownload.upsert_all()
+  end
+
+  defp upsert_log(date, complete) do
+    %Castle.RollupLog{table_name: "monthly_downloads", date: date, complete: complete}
+    |> Castle.RollupLog.upsert!()
   end
 end

--- a/test/rollup/task_test.exs
+++ b/test/rollup/task_test.exs
@@ -1,0 +1,61 @@
+defmodule Castle.RollupTaskTest do
+  use Castle.DataCase, async: true
+  use Castle.RedisCase
+  use Castle.TimeHelpers
+
+  defmodule DefaultsTask do
+    use Castle.Rollup.Task
+    def run(_args), do: nil
+  end
+
+  defmodule FakeTask do
+    use Castle.Rollup.Task
+    @table "foo"
+    @lock_ttl 100
+    @default_count 1
+    def run(_args), do: nil
+    def done(log), do: set_complete(log)
+    def undone(log), do: set_incomplete(log)
+  end
+
+  setup do
+    redis_clear("lock.rollup.*")
+    []
+  end
+
+  test "has default attributes" do
+    assert DefaultsTask.get_attribute(:table) == "does_not_exist"
+    assert DefaultsTask.get_attribute(:lock) == "lock.rollup"
+    assert DefaultsTask.get_attribute(:lock_ttl) == 50
+    assert DefaultsTask.get_attribute(:lock_success_ttl) == 200
+    assert DefaultsTask.get_attribute(:default_count) == 5
+  end
+
+  test "has override values" do
+    assert FakeTask.get_attribute(:table) == "foo"
+    assert FakeTask.get_attribute(:lock_ttl) == 100
+    assert FakeTask.get_attribute(:default_count) == 1
+  end
+
+  test "locks the worker function" do
+    assert ["val1"] == FakeTask.do_rollup [date: "20180101", lock: true], fn(_) -> "val1" end
+    assert [:locked] == FakeTask.do_rollup [date: "20180101", lock: true], fn(_) -> "val2" end
+  end
+
+  test "iterates through dates" do
+    today = Timex.now |> Timex.to_date
+    yesterday = today |> Timex.shift(days: -1)
+    roll1 = FakeTask.do_rollup [], fn(log) ->
+      FakeTask.done(log)
+      log.date
+    end
+    roll2 = FakeTask.do_rollup [], fn(log) ->
+      FakeTask.undone(log)
+      log.date
+    end
+    roll3 = FakeTask.do_rollup [], fn(log) -> log.date end
+    assert [today] == roll1
+    assert [yesterday] == roll2
+    assert [yesterday] == roll3
+  end
+end

--- a/test/rollup/tasks/monthly_test.exs
+++ b/test/rollup/tasks/monthly_test.exs
@@ -1,0 +1,20 @@
+defmodule Castle.RollupTasksMonthlyTest do
+  use Castle.DataCase, async: true
+  use Castle.TimeHelpers
+
+  test "identifies past months 1 day after they're over" do
+    assert is_past_month?(~D[2018-04-01], "2018-03-29T00:00:00Z") == false
+    assert is_past_month?(~D[2018-04-01], "2018-04-01T00:00:00Z") == false
+    assert is_past_month?(~D[2018-04-01], "2018-04-30T23:59:59Z") == false
+    assert is_past_month?(~D[2018-04-01], "2018-05-01T00:00:00Z") == false
+    assert is_past_month?(~D[2018-04-01], "2018-05-01T23:59:59Z") == false
+    assert is_past_month?(~D[2018-04-01], "2018-05-02T00:00:00Z") == true
+    assert is_past_month?(~D[2018-04-01], "2018-05-02T00:00:01Z") == true
+    assert is_past_month?(~D[2018-04-01], "2018-05-15T00:00:00Z") == true
+  end
+
+  def is_past_month?(date, dtim_str) do
+    Mix.Tasks.Castle.Rollup.Monthly.is_past_month? date, get_dtim(dtim_str)
+  end
+
+end


### PR DESCRIPTION
See #63.

- Add `monthly_downloads` table, for faster access to podcast/episode totals.  (Rolled up from postgres hourly_downloads)
- Add `daily_geo_countries` `daily_geo_countries` and `daily_geo_subdivs` partitioned tables
- General DRY-ing up rollup tasks/queries/etc