### PR TITLE
User agent rollups

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -48,4 +48,5 @@ config :castle, Castle.Scheduler,
     # {"* * * * *", {Rollup.Geocountries, :run, [["--lock"]]}},
     # {"* * * * *", {Rollup.Geometros,    :run, [["--lock"]]}},
     # {"* * * * *", {Rollup.Geosubdivs,   :run, [["--lock"]]}},
+    # {"* * * * *", {Rollup.Agents,       :run, [["--lock"]]}},
   ]

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -33,6 +33,7 @@ config :castle, Castle.Scheduler,
     {"20,50 * * * *", {Rollup.Geocountries, :run, [["--lock"]]}},
     {"25,55 * * * *", {Rollup.Geometros,    :run, [["--lock"]]}},
     {"30,0 * * * *",  {Rollup.Geosubdivs,   :run, [["--lock"]]}},
+    {"35,5 * * * *",  {Rollup.Agents,       :run, [["--lock"]]}},
   ]
 
 # ## SSL Support

--- a/lib/big_query/rollup.ex
+++ b/lib/big_query/rollup.ex
@@ -5,6 +5,8 @@ defmodule BigQuery.Rollup do
 
   defdelegate hourly_downloads(), to: BigQuery.Rollup.HourlyDownloads, as: :query
   defdelegate hourly_downloads(d), to: BigQuery.Rollup.HourlyDownloads, as: :query
+  defdelegate daily_agents(), to: BigQuery.Rollup.DailyAgents, as: :query
+  defdelegate daily_agents(d), to: BigQuery.Rollup.DailyAgents, as: :query
   defdelegate daily_geo_countries(), to: BigQuery.Rollup.DailyGeoCountries, as: :query
   defdelegate daily_geo_countries(d), to: BigQuery.Rollup.DailyGeoCountries, as: :query
   defdelegate daily_geo_metros(), to: BigQuery.Rollup.DailyGeoMetros, as: :query

--- a/lib/big_query/rollup/daily_agents.ex
+++ b/lib/big_query/rollup/daily_agents.ex
@@ -1,0 +1,36 @@
+defmodule BigQuery.Rollup.DailyAgents do
+  alias BigQuery.Base.Query, as: Query
+
+  def query(), do: query(Timex.now)
+  def query(dtim) do
+    BigQuery.Rollup.for_day dtim, fn(day) ->
+      {:ok, date_str} = Timex.format(day, "{YYYY}-{0M}-{0D}")
+      Query.query(%{date_str: date_str}, sql()) |> format_results(day)
+    end
+  end
+
+  defp sql do
+    """
+    SELECT
+      ANY_VALUE(feeder_podcast) as podcast_id,
+      feeder_episode as episode_id,
+      IFNULL(agent_name_id, 0) as agent_name_id,
+      IFNULL(agent_type_id, 0) as agent_type_id,
+      IFNULL(agent_os_id, 0) as agent_os_id,
+      count(*) as count
+    FROM dt_downloads
+    WHERE EXTRACT(DATE from timestamp) = @date_str AND is_duplicate = false
+      AND feeder_podcast IS NOT NULL AND feeder_episode IS NOT NULL
+    GROUP BY feeder_episode, agent_name_id, agent_type_id, agent_os_id
+    """
+  end
+
+  defp format_results({rows, meta}, from) do
+    day = Timex.beginning_of_day(from) |> Timex.to_date()
+    {Enum.map(rows, &(format_result(&1, day))), meta}
+  end
+
+  defp format_result(row, day) do
+    Map.put(row, :day, day)
+  end
+end

--- a/lib/castle/daily_agent.ex
+++ b/lib/castle/daily_agent.ex
@@ -1,0 +1,36 @@
+defmodule Castle.DailyAgent do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  @primary_key false
+
+  schema "daily_agents" do
+    field :podcast_id, :integer
+    field :episode_id, :binary_id
+    field :agent_name_id, :integer
+    field :agent_type_id, :integer
+    field :agent_os_id, :integer
+    field :day, :date
+    field :count, :integer
+  end
+
+  @doc false
+  def changeset(download, attrs) do
+    download
+    |> cast(attrs, [:podcast_id, :episode_id, :agent_name_id, :agent_type_id, :agent_os_id, :day, :count])
+    |> validate_required([:podcast_id, :episode_id, :agent_name_id, :agent_type_id, :agent_os_id, :day, :count])
+  end
+
+  def upsert(row), do: upsert_all([row])
+
+  def upsert_all([]), do: 0
+  def upsert_all(rows) when length(rows) > 5000 do
+    Enum.chunk_every(rows, 5000)
+    |> Enum.map(&upsert_all/1)
+    |> Enum.sum()
+  end
+  def upsert_all(rows) do
+    Castle.Repo.insert_all Castle.DailyAgent, rows
+    length(rows)
+  end
+end

--- a/lib/rollup/tasks/agents.ex
+++ b/lib/rollup/tasks/agents.ex
@@ -1,0 +1,33 @@
+defmodule Mix.Tasks.Castle.Rollup.Agents do
+  use Castle.Rollup.Task
+
+  @shortdoc "Rollup bigquery user agents by day"
+
+  @table "daily_agents"
+  @lock "lock.rollup.agents"
+
+  def run(args) do
+    {:ok, _started} = Application.ensure_all_started(:castle)
+
+    {opts, _, _} = OptionParser.parse args,
+      switches: [lock: :boolean, date: :string, count: :integer],
+      aliases: [l: :lock, d: :date, c: :count]
+
+    do_rollup(opts, &rollup/1)
+  end
+
+  def rollup(rollup_log) do
+    Logger.info "Rollup.DailyAgent.#{rollup_log.date} querying"
+    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.daily_agents()
+    Logger.info "Rollup.DailyAgent.#{rollup_log.date} upserting #{length(results)}"
+    Castle.DailyAgent.upsert_all(results)
+    case meta do
+      %{complete: true} ->
+        set_complete(rollup_log)
+        Logger.info "Rollup.DailyAgent.#{rollup_log.date} complete"
+      %{complete: false, hours_complete: h} ->
+        set_incomplete(rollup_log)
+        Logger.info "Rollup.DailyAgent.#{rollup_log.date} incomplete (#{h}/24 hours)"
+    end
+  end
+end

--- a/priv/repo/migrations/20180530194450_create_daily_agents.exs
+++ b/priv/repo/migrations/20180530194450_create_daily_agents.exs
@@ -1,0 +1,59 @@
+defmodule Castle.Repo.Migrations.CreateDailyAgents do
+  use Ecto.Migration
+
+  def change do
+    create table(:daily_agents, primary_key: false) do
+      add :podcast_id, :integer, null: false
+      add :episode_id, :uuid, null: false
+      add :agent_name_id, :integer, null: false, default: 0
+      add :agent_type_id, :integer, null: false, default: 0
+      add :agent_os_id, :integer, null: false, default: 0
+      add :day, :date, null: false
+      add :count, :integer, null: false
+    end
+
+    execute """
+    CREATE OR REPLACE FUNCTION create_daily_agents_partition() RETURNS trigger AS
+    $$
+      DECLARE
+        partition_start DATE;
+        partition_end DATE;
+        partition TEXT;
+      BEGIN
+        partition_start := DATE_TRUNC('MONTH', NEW.day);
+        partition_end := partition_start + INTERVAL '1 MONTH';
+        partition := 'daily_agents_' || to_char(NEW.day,'YYYYMM');
+        IF NOT EXISTS(SELECT relname FROM pg_class WHERE relname=partition) THEN
+          RAISE NOTICE 'A partition has been created %',partition;
+          EXECUTE 'CREATE TABLE ' || partition || ' (CHECK (day >= DATE ''' || partition_start || ''' AND day < DATE ''' || partition_end || '''), CONSTRAINT ' || partition || '_uniq UNIQUE (episode_id, agent_name_id, agent_type_id, agent_os_id, day)) INHERITS (daily_agents);';
+          EXECUTE 'CREATE INDEX ' || partition || '_podcast_id_index ON ' || partition || ' (podcast_id);';
+          EXECUTE 'CREATE INDEX ' || partition || '_episode_id_index ON ' || partition || ' (episode_id);';
+          EXECUTE 'CREATE INDEX ' || partition || '_day_index ON ' || partition || ' (day);';
+        END IF;
+        EXECUTE 'INSERT INTO ' || partition || ' SELECT(daily_agents ' || quote_literal(NEW) || ').* ON CONFLICT ON CONSTRAINT ' || partition || '_uniq DO UPDATE SET (podcast_id, count) = (' || NEW.podcast_id || ', ' || NEW.count || ');';
+        RETURN NULL;
+      END;
+    $$ LANGUAGE plpgsql;
+    """
+
+    execute """
+    CREATE TRIGGER daily_agents_partition_insert_trigger
+    BEFORE INSERT ON daily_agents
+    FOR EACH ROW EXECUTE PROCEDURE create_daily_agents_partition();
+    """
+  end
+
+  def down do
+    Enum.map inherited_tables(), fn(table_name) ->
+      drop table(table_name)
+    end
+    drop table(:daily_agents)
+    execute "DROP FUNCTION create_daily_agents_partition()"
+  end
+
+  defp inherited_tables do
+    query = "select tablename from pg_tables where tablename like 'daily_agents\_______'"
+    result = Ecto.Adapters.SQL.query!(Castle.Repo, query, [])
+    List.flatten(result.rows)
+  end
+end


### PR DESCRIPTION
~Merge #69 first.  The diff here will be pretty busy until then.~

Implements #70.

- Adds a single `daily_agents` partitioned table (and models/rollups/tasks)
- Rolling up by all 3 of "agent name+type+os" into a single table, and including nulls, there are only about 50K rows per day.  Which is actually a bit less than each of the 3 separate geo tables.  So I think it's fine to use a single table for the 3 facets.
- Uses "0" as an alias for NULLs, so that the postgres constraint/upsert magic works.  (Otherwise, postgres allows duplicate rows, since `null != null`).