### PR TITLE
DB timeouts

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,13 +7,13 @@ use Mix.Config
 
 # General application configuration
 config :castle, ecto_repos: [Castle.Repo]
-config :castle, Castle.Repo, adapter: Ecto.Adapters.Postgres
+config :castle, Castle.Repo, adapter: Ecto.Adapters.Postgres, timeout: 30_000
 
 # Configures the endpoint
 config :castle, CastleWeb.Endpoint,
   url: [host: "localhost"],
   secret_key_base: "+DVZXtoG6yRaQrhCNCPNjdyhioRgRlrKMUDDlZkPLXCghP4NCJ+JafxydZD/QnOq",
-  render_errors: [view: CastleWeb.ErrorView, accepts: ~w(html json)],
+  render_errors: [view: CastleWeb.ErrorView, accepts: ~w(html json hal)],
   pubsub: [name: Castle.PubSub,
            adapter: Phoenix.PubSub.PG2]
 

--- a/test/feeder/sync_episodes_test.exs
+++ b/test/feeder/sync_episodes_test.exs
@@ -23,7 +23,11 @@ defmodule Feeder.SyncEpisodesTest do
     assert {:ok, 3, 0, 7} = Feeder.SyncEpisodes.sync()
   end
 
-  defp updates_and_creates(total) do
+  test_with_http "skips episodes with no podcast", %{@episodes => updates_and_creates(10, true)} do
+    assert {:ok, 2, 0, 8} = Feeder.SyncEpisodes.sync()
+  end
+
+  defp updates_and_creates(total, skip_podcast \\ false) do
     %{
       "total" => total,
       "_embedded" => %{
@@ -32,23 +36,28 @@ defmodule Feeder.SyncEpisodesTest do
             "id" => @id1,
             "title" => "one",
             "updatedAt" => "2018-04-25T05:00:00Z",
-            "_links" => %{"prx:podcast" => %{"href" => "/api/v1/podcasts/123"}}
+            "_links" => podcast_link(123, false)
           },
           %{
             "id" => @id2,
             "title" => "two-changed",
             "updatedAt" => "2018-04-25T05:00:00Z",
-            "_links" => %{"prx:podcast" => %{"href" => "/api/v1/podcasts/123"}}
+            "_links" => podcast_link(456, skip_podcast)
           },
           %{
             "id" => @id3,
             "title" => "three",
             "updatedAt" => "2018-04-25T05:00:00Z",
-            "_links" => %{"prx:podcast" => %{"href" => "/api/v1/podcasts/123"}}
+            "_links" => podcast_link(789, false)
           },
         ]
       }
     }
+  end
+
+  defp podcast_link(_id, true), do: %{}
+  defp podcast_link(id, false) do
+    %{"prx:podcast" => %{"href" => "/api/v1/podcasts/#{id}"}}
   end
 
 end


### PR DESCRIPTION
See #79.

Other things:

- [x] Skip syncing feeder episodes with no podcast
- [x] Fix error rendering in prod, when client accepts `application/hal+json`

With that out of the way, it seems to just be a specific handler checking out the db connection for longer than 15 seconds (the default timeout).  Appears to be related to how metrics requests data - it fires off 20+ requests at once.  Bumping the db pool size also helps - going to do that too (it's an ENV).