### PR TITLE
adds interval and group to total route params

### DIFF
--- a/lib/castle_web/views/api/episode_view.ex
+++ b/lib/castle_web/views/api/episode_view.ex
@@ -52,7 +52,7 @@ defmodule CastleWeb.API.EpisodeView do
        templated: true,
       },
       "prx:totals": %{
-        href: api_episode_total_path(conn, :index, episode.id) <> "{?from,to}",
+        href: api_episode_total_path(conn, :index, episode.id) <> "{?interval,from,to,group}",
         templated: true,
       },
     } |> episode_image_link(episode.image_url)

--- a/lib/castle_web/views/api/episode_view.ex
+++ b/lib/castle_web/views/api/episode_view.ex
@@ -52,7 +52,7 @@ defmodule CastleWeb.API.EpisodeView do
        templated: true,
       },
       "prx:totals": %{
-        href: api_episode_total_path(conn, :index, episode.id) <> "{?interval,from,to,group}",
+        href: api_episode_total_path(conn, :index, episode.id) <> "{?from,to,group}",
         templated: true,
       },
     } |> episode_image_link(episode.image_url)

--- a/lib/castle_web/views/api/podcast_view.ex
+++ b/lib/castle_web/views/api/podcast_view.ex
@@ -49,7 +49,7 @@ defmodule CastleWeb.API.PodcastView do
        templated: true,
       },
       "prx:totals": %{
-        href: api_podcast_total_path(conn, :index, podcast.id) <> "{?interval,from,to,group}",
+        href: api_podcast_total_path(conn, :index, podcast.id) <> "{?from,to,group}",
         templated: true,
       },
     } |> podcast_image_link(podcast.image_url)

--- a/lib/castle_web/views/api/podcast_view.ex
+++ b/lib/castle_web/views/api/podcast_view.ex
@@ -49,7 +49,7 @@ defmodule CastleWeb.API.PodcastView do
        templated: true,
       },
       "prx:totals": %{
-        href: api_podcast_total_path(conn, :index, podcast.id) <> "{?from,to}",
+        href: api_podcast_total_path(conn, :index, podcast.id) <> "{?interval,from,to,group}",
         templated: true,
       },
     } |> podcast_image_link(podcast.image_url)

--- a/lib/castle_web/views/api/root_view.ex
+++ b/lib/castle_web/views/api/root_view.ex
@@ -45,7 +45,7 @@ defmodule CastleWeb.API.RootView do
           templated: true,
         }],
         "prx:podcast-totals": [%{
-          href: fix_path(api_podcast_total_path(conn, :index, "{id}") <> "{?interval,from,to,group}"),
+          href: fix_path(api_podcast_total_path(conn, :index, "{id}") <> "{?from,to,group}"),
           templated: true,
         }],
         "prx:episode-downloads": [%{
@@ -57,7 +57,7 @@ defmodule CastleWeb.API.RootView do
           templated: true,
         }],
         "prx:episode-totals": [%{
-          href: fix_path(api_episode_total_path(conn, :index, "{id}") <> "{?interval,from,to,group}"),
+          href: fix_path(api_episode_total_path(conn, :index, "{id}") <> "{?from,to,group}"),
           templated: true,
         }],
       }

--- a/lib/castle_web/views/api/root_view.ex
+++ b/lib/castle_web/views/api/root_view.ex
@@ -45,7 +45,7 @@ defmodule CastleWeb.API.RootView do
           templated: true,
         }],
         "prx:podcast-totals": [%{
-          href: fix_path(api_podcast_total_path(conn, :index, "{id}") <> "{?from,to}"),
+          href: fix_path(api_podcast_total_path(conn, :index, "{id}") <> "{?interval,from,to,group}"),
           templated: true,
         }],
         "prx:episode-downloads": [%{
@@ -57,7 +57,7 @@ defmodule CastleWeb.API.RootView do
           templated: true,
         }],
         "prx:episode-totals": [%{
-          href: fix_path(api_episode_total_path(conn, :index, "{id}") <> "{?from,to}"),
+          href: fix_path(api_episode_total_path(conn, :index, "{id}") <> "{?interval,from,to,group}"),
           templated: true,
         }],
       }


### PR DESCRIPTION
Hal service caught that the group and interval params were missing from the views.