### PR TITLE
Filter ranks/totals

### DIFF
--- a/lib/castle.ex
+++ b/lib/castle.ex
@@ -18,7 +18,7 @@ defmodule Castle do
 
   defmodule Grouping do
     @enforce_keys [:name, :ranks, :totals, :labels]
-    defstruct [:name, :ranks, :totals, :labels, limit: 10]
+    defstruct [:name, :ranks, :totals, :labels, :filters, limit: 10]
   end
 
 end

--- a/lib/castle_web/views/api/episode_view.ex
+++ b/lib/castle_web/views/api/episode_view.ex
@@ -48,11 +48,11 @@ defmodule CastleWeb.API.EpisodeView do
         templated: true,
       },
       "prx:ranks": %{
-        href: api_episode_rank_path(conn, :index, episode.id) <> "{?interval,from,to,group,limit}",
+        href: api_episode_rank_path(conn, :index, episode.id) <> "{?interval,from,to,group,limit,filters}",
        templated: true,
       },
       "prx:totals": %{
-        href: api_episode_total_path(conn, :index, episode.id) <> "{?from,to,group}",
+        href: api_episode_total_path(conn, :index, episode.id) <> "{?from,to,group,filters}",
         templated: true,
       },
     } |> episode_image_link(episode.image_url)

--- a/lib/castle_web/views/api/podcast_view.ex
+++ b/lib/castle_web/views/api/podcast_view.ex
@@ -45,11 +45,11 @@ defmodule CastleWeb.API.PodcastView do
         templated: true,
       },
       "prx:ranks": %{
-        href: api_podcast_rank_path(conn, :index, podcast.id) <> "{?interval,from,to,group,limit}",
+        href: api_podcast_rank_path(conn, :index, podcast.id) <> "{?interval,from,to,group,limit,filters}",
        templated: true,
       },
       "prx:totals": %{
-        href: api_podcast_total_path(conn, :index, podcast.id) <> "{?from,to,group}",
+        href: api_podcast_total_path(conn, :index, podcast.id) <> "{?from,to,group,filters}",
         templated: true,
       },
     } |> podcast_image_link(podcast.image_url)

--- a/lib/castle_web/views/api/root_view.ex
+++ b/lib/castle_web/views/api/root_view.ex
@@ -41,11 +41,11 @@ defmodule CastleWeb.API.RootView do
           templated: true,
         }],
         "prx:podcast-ranks": [%{
-          href: fix_path(api_podcast_rank_path(conn, :index, "{id}") <> "{?interval,from,to,group,limit}"),
+          href: fix_path(api_podcast_rank_path(conn, :index, "{id}") <> "{?interval,from,to,group,limit,filters}"),
           templated: true,
         }],
         "prx:podcast-totals": [%{
-          href: fix_path(api_podcast_total_path(conn, :index, "{id}") <> "{?from,to,group}"),
+          href: fix_path(api_podcast_total_path(conn, :index, "{id}") <> "{?from,to,group,filters}"),
           templated: true,
         }],
         "prx:episode-downloads": [%{
@@ -53,11 +53,11 @@ defmodule CastleWeb.API.RootView do
           templated: true,
         }],
         "prx:episode-ranks": [%{
-          href: fix_path(api_episode_rank_path(conn, :index, "{guid}") <> "{?interval,from,to,group,limit}"),
+          href: fix_path(api_episode_rank_path(conn, :index, "{guid}") <> "{?interval,from,to,group,limit,filters}"),
           templated: true,
         }],
         "prx:episode-totals": [%{
-          href: fix_path(api_episode_total_path(conn, :index, "{id}") <> "{?from,to,group}"),
+          href: fix_path(api_episode_total_path(conn, :index, "{id}") <> "{?from,to,group,filters}"),
           templated: true,
         }],
       }

--- a/lib/rollup/query/geo_totals.ex
+++ b/lib/rollup/query/geo_totals.ex
@@ -1,31 +1,33 @@
 defmodule Castle.Rollup.Query.GeoTotals do
   import Ecto.Query
 
-  def podcast(id, %{from: from, to: to}, %{name: grouping_name}) do
-    podcast(id, from, to, grouping_name)
+  def podcast(id, %{from: from, to: to}, %{name: name, filters: filters}) do
+    podcast(id, from, to, name, nil, filters)
   end
-  def podcast(id, from, to, grouping_name, grouping_limit \\ nil) do
+  def podcast(id, from, to, grouping_name, limit \\ nil, filters \\ nil) do
     table(grouping_name)
     |> select([t], %{count: sum(t.count)})
     |> select_grouping(grouping_name)
     |> where_podcast(id)
     |> where_timeframe(from, to)
+    |> where_filters(grouping_name, filters)
     |> order_by([t], [desc: sum(t.count)])
-    |> with_limit(grouping_limit)
+    |> with_limit(limit)
     |> Castle.Repo.NewRelic.all
   end
 
-  def episode(id, %{from: from, to: to}, %{name: grouping_name}) do
-    episode(id, from, to, grouping_name)
+  def episode(id, %{from: from, to: to}, %{name: name, filters: filters}) do
+    episode(id, from, to, name, nil, filters)
   end
-  def episode(id, from, to, grouping_name, grouping_limit \\ nil) do
+  def episode(id, from, to, grouping_name, limit \\ nil, filters \\ nil) do
     table(grouping_name)
     |> select([t], %{count: sum(t.count)})
     |> select_grouping(grouping_name)
     |> where_episode(id)
     |> where_timeframe(from, to)
+    |> where_filters(grouping_name, filters)
     |> order_by([t], [desc: sum(t.count)])
-    |> with_limit(grouping_limit)
+    |> with_limit(limit)
     |> Castle.Repo.NewRelic.all
   end
 
@@ -57,6 +59,12 @@ defmodule Castle.Rollup.Query.GeoTotals do
   defp where_timeframe(query, from, to) do
     where(query, [t], t.day >= ^from and t.day < ^to)
   end
+
+  defp where_filters(query, "geosubdiv", %{geocountry: codes}) do
+    codes_list = String.split(codes, "|", trim: true)
+    where(query, [t], t.country_iso_code in ^codes_list)
+  end
+  defp where_filters(query, _, _), do: query
 
   defp with_limit(query, nil), do: query
   defp with_limit(query, num), do: limit(query, ^num)

--- a/test/plugs/group_plug_test.exs
+++ b/test/plugs/group_plug_test.exs
@@ -2,54 +2,61 @@ defmodule Castle.PlugsGroupTest do
   use Castle.ConnCase, async: true
 
   test "groups by country", %{conn: conn} do
-    group = get_group(conn, "geocountry")
+    group = get_group(conn, %{group: "geocountry"})
     assert group.name == "geocountry"
     assert group.limit == 10
   end
 
   test "groups by subdivision", %{conn: conn} do
-    group = get_group(conn, "geosubdiv")
+    group = get_group(conn, %{group: "geosubdiv"})
     assert group.name == "geosubdiv"
     assert group.limit == 10
   end
 
   test "requires a grouping", %{conn: conn} do
-    conn = call_group(conn, nil, nil)
+    conn = call_group(conn, %{})
     assert conn.status == 400
     assert conn.halted == true
     assert conn.resp_body =~ ~r/you must set a group param/i
   end
 
+  test "parses filters", %{conn: conn} do
+    assert get_group(conn, %{group: "geosubdiv"}).filters == nil
+    assert get_group(conn, %{group: "geosubdiv", filters: ""}).filters == nil
+    assert get_group(conn, %{group: "geosubdiv", filters: "foo,bar=stuff"}).filters == %{foo: true, bar: "stuff"}
+    assert get_group(conn, %{group: "geosubdiv", filters: "foo:false,bar"}).filters == %{foo: false, bar: true}
+    assert get_group(conn, %{group: "geosubdiv", filters: "foo=true,bar:"}).filters == %{foo: true, bar: true}
+  end
+
   test "overrides limits", %{conn: conn} do
-    assert get_group(conn, "geocountry", "11").limit == 11
-    assert get_group(conn, "geocountry", "2").limit == 2
+    assert get_group(conn, %{group: "geocountry", limit: "11"}).limit == 11
+    assert get_group(conn, %{group: "geocountry", limit: "2"}).limit == 2
   end
 
   test "validates groupings", %{conn: conn} do
-    conn = call_group(conn, "foo")
+    conn = call_group(conn, %{group: "foo"})
     assert conn.status == 400
     assert conn.halted == true
     assert conn.resp_body =~ ~r/bad group param/i
   end
 
   test "validates grouping limits", %{conn: conn} do
-    conn = call_group(conn, "geocountry", "foo")
+    conn = call_group(conn, %{group: "geocountry", limit: "foo"})
     assert conn.status == 400
     assert conn.halted == true
     assert conn.resp_body =~ ~r/limit is not an integer/i
   end
 
-  defp get_group(conn, group, limit \\ nil) do
-    conn |> call_group(group, limit) |> Map.get(:assigns) |> Map.get(:group)
+  defp get_group(conn, params) do
+    conn |> call_group(params) |> Map.get(:assigns) |> Map.get(:group)
   end
 
-  defp call_group(conn, group, limit \\ nil) do
-    conn |> set_group(group, limit) |> Castle.Plugs.Group.call(%{})
+  defp call_group(conn, params) do
+    conn |> set_group(params) |> Castle.Plugs.Group.call(%{})
   end
 
-  defp set_group(conn, nil, nil), do: conn
-  defp set_group(conn, group, nil), do: Map.merge(conn, %{params: %{"group" => group}})
-  defp set_group(conn, group, limit) do
-    Map.merge(conn, %{params: %{"group" => group, "limit" => limit}})
+  defp set_group(conn, params) do
+    str_params = Map.new(params, fn({k, v}) -> {Atom.to_string(k), v} end)
+    Map.merge(conn, %{params: str_params})
   end
 end

--- a/test/rollup/query/geo_ranks_test.exs
+++ b/test/rollup/query/geo_ranks_test.exs
@@ -52,6 +52,8 @@ defmodule Castle.RollupQueryGeoRanksTest do
         day: ~D[2018-04-24], country_iso_code: "US", subdivision_1_iso_code: "CO"}
       Castle.DailyGeoSubdiv.upsert %{podcast_id: @id, episode_id: @guid1, count: 22,
         day: ~D[2018-04-24], country_iso_code: "US", subdivision_1_iso_code: "CA"}
+      Castle.DailyGeoSubdiv.upsert %{podcast_id: @id, episode_id: @guid1, count: 1,
+        day: ~D[2018-04-24], country_iso_code: "CA", subdivision_1_iso_code: "ON"}
       Castle.DailyGeoSubdiv.upsert %{podcast_id: @id, episode_id: @guid2, count: 33,
         day: ~D[2018-04-25], country_iso_code: "US", subdivision_1_iso_code: "CO"}
       Castle.DailyGeoSubdiv.upsert %{podcast_id: @id, episode_id: @guid1, count: 44,
@@ -64,7 +66,7 @@ defmodule Castle.RollupQueryGeoRanksTest do
       assert ranks == ["US-CO", "US-MN", nil]
       assert length(datas) == 4
       assert_result datas, 0, "US-CO", 11, "2018-04-24"
-      assert_result datas, 1, nil, 22, "2018-04-24"
+      assert_result datas, 1, nil, 23, "2018-04-24"
       assert_result datas, 2, "US-CO", 33, "2018-04-25"
       assert_result datas, 3, "US-MN", 44, "2018-04-25"
     end
@@ -74,8 +76,15 @@ defmodule Castle.RollupQueryGeoRanksTest do
       assert ranks == ["US-MN", "US-CA", nil]
       assert length(datas) == 3
       assert_result datas, 0, "US-CA", 22, "2018-04-24"
-      assert_result datas, 1, nil, 11, "2018-04-24"
+      assert_result datas, 1, nil, 12, "2018-04-24"
       assert_result datas, 2, "US-MN", 44, "2018-04-25"
+    end
+
+    test "filters by a country", %{t1: t1, t2: t2} do
+      {ranks, datas} = podcast(@id, t1, t2, "day", "geosubdiv", 10, %{geocountry: "GB|CA"})
+      assert ranks == ["CA-ON", nil]
+      assert length(datas) == 1
+      assert_result datas, 0, "CA-ON", 1, "2018-04-24"
     end
 
   end

--- a/test/rollup/query/geo_totals_test.exs
+++ b/test/rollup/query/geo_totals_test.exs
@@ -50,16 +50,20 @@ defmodule Castle.RollupQueryGeoTotalsTest do
         day: ~D[2018-04-24], country_iso_code: "US", subdivision_1_iso_code: "CA"}
       Castle.DailyGeoSubdiv.upsert %{podcast_id: @id, episode_id: @guid2, count: 33,
         day: ~D[2018-04-25], country_iso_code: "US", subdivision_1_iso_code: "CO"}
+      Castle.DailyGeoSubdiv.upsert %{podcast_id: @id, episode_id: @guid2, count: 1,
+        day: ~D[2018-04-25], country_iso_code: "CA", subdivision_1_iso_code: "ON"}
       [t1: get_dtim("2018-04-24T00:00:00"), t2: get_dtim("2018-04-26T00:00:00")]
     end
 
     test "totals a podcast", %{t1: t1, t2: t2} do
       totals = podcast(@id, t1, t2, "geosubdiv")
-      assert length(totals) == 2
+      assert length(totals) == 3
       assert Enum.at(totals, 0).group == "US-CO"
       assert Enum.at(totals, 0).count == 44
       assert Enum.at(totals, 1).group == "US-CA"
       assert Enum.at(totals, 1).count == 22
+      assert Enum.at(totals, 2).group == "CA-ON"
+      assert Enum.at(totals, 2).count == 1
     end
 
     test "totals an episode", %{t1: t1, t2: t2} do
@@ -69,6 +73,13 @@ defmodule Castle.RollupQueryGeoTotalsTest do
       assert Enum.at(totals, 0).count == 22
       assert Enum.at(totals, 1).group == "US-CO"
       assert Enum.at(totals, 1).count == 11
+    end
+
+    test "filters by a country", %{t1: t1, t2: t2} do
+      totals = podcast(@id, t1, t2, "geosubdiv", nil, %{geocountry: "GB|CA"})
+      assert length(totals) == 1
+      assert Enum.at(totals, 0).group == "CA-ON"
+      assert Enum.at(totals, 0).count == 1
     end
 
   end


### PR DESCRIPTION
Adds a `?filters` param to the ranks and totals endpoints.

Filters are of the form `?filters=key1:value1,key2:value2` (or url encode a `=` instead of `:`).

The only supported filter is for `group=geosubdiv`, and you can filter for one or more country code with:

- `?filters=geocountry:US`
- `?filters=geocountry:CA|US`
- `?filters=geocountry:CA|US|MX`