### PR TITLE
WIP fewer upserts

### DIFF
--- a/lib/castle/rollup_log.ex
+++ b/lib/castle/rollup_log.ex
@@ -26,6 +26,19 @@ defmodule Castle.RollupLog do
     Castle.Repo.insert!(log, on_conflict: conflict, conflict_target: target)
   end
 
+  def query_from_time(rollup_log) do
+    if rollup_log.updated_at && rollup_log.date == Timex.today do
+      from = Timex.shift(rollup_log.updated_at, seconds: -@buffer_seconds)
+      if from.day == rollup_log.date.day do
+        Castle.Bucket.Hourly.floor(from)
+      else
+        Timex.to_datetime(rollup_log.date)
+      end
+    else
+      Timex.to_datetime(rollup_log.date)
+    end
+  end
+
   def find_missing_days(tbl, lim), do: find_missing_days(tbl, lim, default_to_date())
   def find_missing_days(table_name, limit, to_date) do
     find_missing table_name, limit, """

--- a/lib/rollup/task.ex
+++ b/lib/rollup/task.ex
@@ -20,19 +20,20 @@ defmodule Castle.Rollup.Task do
       @lock_success_ttl 200
       @default_count 5
 
-      def do_rollup(args, work_fn) when is_list(args) do
-        Enum.into(args, %{}) |> do_rollup(work_fn)
+      def rollup(), do: rollup(%{})
+      def rollup(args) when is_list(args) do
+        Enum.into(args, %{}) |> rollup()
       end
-      def do_rollup(%{lock: true} = args, work_fn) do
+      def rollup(%{lock: true} = args) do
         lock = get_attribute(:lock)
         lock_ttl = get_attribute(:lock_ttl)
         success_ttl = get_attribute(:lock_success_ttl)
         find_rollup_logs(args) |> Enum.map(fn(log) ->
-          lock "#{lock}.#{log.date}", lock_ttl, success_ttl, do: work_fn.(log)
+          lock "#{lock}.#{log.date}", lock_ttl, success_ttl, do: do_rollup(log)
         end)
       end
-      def do_rollup(args, work_fn) do
-        find_rollup_logs(args) |> Enum.map(&(work_fn.(&1)))
+      def rollup(args) do
+        find_rollup_logs(args) |> Enum.map(&(do_rollup(&1)))
       end
 
       # get attribute from caller module, OR this one
@@ -53,6 +54,25 @@ defmodule Castle.Rollup.Task do
         end
       end
       defp find_rollup_logs(_opts), do: find_rollup_logs(%{count: get_attribute(:default_count)})
+
+      defp do_rollup(rollup_log) do
+        log(rollup_log.date, "querying")
+        {results, meta} = rollup_log.date |> Timex.to_datetime() |> query()
+        log(rollup_log.date, "upserting #{length(results)}")
+        upsert(results)
+        case meta do
+          %{complete: true} ->
+            set_complete(rollup_log)
+            log(rollup_log.date, "complete")
+          %{complete: false, hours_complete: h} ->
+            set_incomplete(rollup_log)
+            log(rollup_log.date, "incomplete (#{h}/24 hours)")
+          %{complete: false} ->
+            set_incomplete(rollup_log)
+            log(rollup_log.date, "incomplete")
+        end
+        rollup_log.date
+      end
 
       defp set_complete(rollup_log) do
         rollup_log |> Map.put(:complete, true) |> Castle.RollupLog.upsert!()

--- a/lib/rollup/tasks/agents.ex
+++ b/lib/rollup/tasks/agents.ex
@@ -13,21 +13,18 @@ defmodule Mix.Tasks.Castle.Rollup.Agents do
       switches: [lock: :boolean, date: :string, count: :integer],
       aliases: [l: :lock, d: :date, c: :count]
 
-    do_rollup(opts, &rollup/1)
+    rollup(opts)
   end
 
-  def rollup(rollup_log) do
-    Logger.info "Rollup.DailyAgent.#{rollup_log.date} querying"
-    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.daily_agents()
-    Logger.info "Rollup.DailyAgent.#{rollup_log.date} upserting #{length(results)}"
+  def log(date, msg) do
+    Logger.info "Rollup.Agents.#{date} #{msg}"
+  end
+
+  def query(time) do
+    BigQuery.Rollup.daily_agents(time)
+  end
+
+  def upsert(results) do
     Castle.DailyAgent.upsert_all(results)
-    case meta do
-      %{complete: true} ->
-        set_complete(rollup_log)
-        Logger.info "Rollup.DailyAgent.#{rollup_log.date} complete"
-      %{complete: false, hours_complete: h} ->
-        set_incomplete(rollup_log)
-        Logger.info "Rollup.DailyAgent.#{rollup_log.date} incomplete (#{h}/24 hours)"
-    end
   end
 end

--- a/lib/rollup/tasks/geocountries.ex
+++ b/lib/rollup/tasks/geocountries.ex
@@ -13,21 +13,18 @@ defmodule Mix.Tasks.Castle.Rollup.Geocountries do
       switches: [lock: :boolean, date: :string, count: :integer],
       aliases: [l: :lock, d: :date, c: :count]
 
-    do_rollup(opts, &rollup/1)
+    rollup(opts)
   end
 
-  def rollup(rollup_log) do
-    Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} querying"
-    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.daily_geo_countries()
-    Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} upserting #{length(results)}"
+  def log(date, msg) do
+    Logger.info "Rollup.GeoCountries.#{date} #{msg}"
+  end
+
+  def query(time) do
+    BigQuery.Rollup.daily_geo_countries(time)
+  end
+
+  def upsert(results) do
     Castle.DailyGeoCountry.upsert_all(results)
-    case meta do
-      %{complete: true} ->
-        set_complete(rollup_log)
-        Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} complete"
-      %{complete: false, hours_complete: h} ->
-        set_incomplete(rollup_log)
-        Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} incomplete (#{h}/24 hours)"
-    end
   end
 end

--- a/lib/rollup/tasks/geometros.ex
+++ b/lib/rollup/tasks/geometros.ex
@@ -13,21 +13,18 @@ defmodule Mix.Tasks.Castle.Rollup.Geometros do
       switches: [lock: :boolean, date: :string, count: :integer],
       aliases: [l: :lock, d: :date, c: :count]
 
-    do_rollup(opts, &rollup/1)
+    rollup(opts)
   end
 
-  def rollup(rollup_log) do
-    Logger.info "Rollup.DailyGeoMetro.#{rollup_log.date} querying"
-    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.daily_geo_metros()
-    Logger.info "Rollup.DailyGeoMetro.#{rollup_log.date} upserting #{length(results)}"
+  def log(date, msg) do
+    Logger.info "Rollup.GeoMetros.#{date} #{msg}"
+  end
+
+  def query(time) do
+    BigQuery.Rollup.daily_geo_metros(time)
+  end
+
+  def upsert(results) do
     Castle.DailyGeoMetro.upsert_all(results)
-    case meta do
-      %{complete: true} ->
-        set_complete(rollup_log)
-        Logger.info "Rollup.DailyGeoMetro.#{rollup_log.date} complete"
-      %{complete: false, hours_complete: h} ->
-        set_incomplete(rollup_log)
-        Logger.info "Rollup.DailyGeoMetro.#{rollup_log.date} incomplete (#{h}/24 hours)"
-    end
   end
 end

--- a/lib/rollup/tasks/geosubdivs.ex
+++ b/lib/rollup/tasks/geosubdivs.ex
@@ -13,21 +13,18 @@ defmodule Mix.Tasks.Castle.Rollup.Geosubdivs do
       switches: [lock: :boolean, date: :string, count: :integer],
       aliases: [l: :lock, d: :date, c: :count]
 
-    do_rollup(opts, &rollup/1)
+    rollup(opts)
   end
 
-  def rollup(rollup_log) do
-    Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} querying"
-    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.daily_geo_subdivs()
-    Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} upserting #{length(results)}"
+  def log(date, msg) do
+    Logger.info "Rollup.GeoSubdivs.#{date} #{msg}"
+  end
+
+  def query(time) do
+    BigQuery.Rollup.daily_geo_subdivs(time)
+  end
+
+  def upsert(results) do
     Castle.DailyGeoSubdiv.upsert_all(results)
-    case meta do
-      %{complete: true} ->
-        set_complete(rollup_log)
-        Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} complete"
-      %{complete: false, hours_complete: h} ->
-        set_incomplete(rollup_log)
-        Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} incomplete (#{h}/24 hours)"
-    end
   end
 end

--- a/test/rollup/task_test.exs
+++ b/test/rollup/task_test.exs
@@ -6,6 +6,9 @@ defmodule Castle.RollupTaskTest do
   defmodule DefaultsTask do
     use Castle.Rollup.Task
     def run(_args), do: nil
+    def log(_, _), do: nil
+    defp query(_), do: {[], %{complete: true}}
+    def upsert(_), do: nil
   end
 
   defmodule FakeTask do
@@ -14,14 +17,28 @@ defmodule Castle.RollupTaskTest do
     @lock_ttl 100
     @default_count 1
     def run(_args), do: nil
-    def done(log), do: set_complete(log)
-    def undone(log), do: set_incomplete(log)
+    def log(_, _), do: nil
+    def query(_), do: {[], %{complete: true}}
+    def upsert(_), do: nil
+  end
+
+  defmodule FakeIncompleteTask do
+    use Castle.Rollup.Task
+    @table "foo"
+    @default_count 1
+    def run(_args), do: nil
+    def log(_, _), do: nil
+    def query(_), do: {[], %{complete: false}}
+    def upsert(_), do: nil
   end
 
   defmodule MonthlyTask do
     use Castle.Rollup.Task
     @interval "month"
     def run(_args), do: nil
+    def log(_, _), do: nil
+    def query(_), do: {[], %{complete: true}}
+    def upsert(_), do: nil
   end
 
   setup do
@@ -44,22 +61,16 @@ defmodule Castle.RollupTaskTest do
   end
 
   test "locks the worker function" do
-    assert ["val1"] == FakeTask.do_rollup [date: "20180101", lock: true], fn(_) -> "val1" end
-    assert [:locked] == FakeTask.do_rollup [date: "20180101", lock: true], fn(_) -> "val2" end
+    assert [~D[2018-01-01]] == FakeTask.rollup([date: "20180101", lock: true])
+    assert [:locked] == FakeTask.rollup([date: "20180101", lock: true])
   end
 
   test "iterates through days" do
     today = Timex.now |> Timex.to_date
     yesterday = today |> Timex.shift(days: -1)
-    roll1 = FakeTask.do_rollup [], fn(log) ->
-      FakeTask.done(log)
-      log.date
-    end
-    roll2 = FakeTask.do_rollup [], fn(log) ->
-      FakeTask.undone(log)
-      log.date
-    end
-    roll3 = FakeTask.do_rollup [], fn(log) -> log.date end
+    roll1 = FakeTask.rollup()
+    roll2 = FakeIncompleteTask.rollup()
+    roll3 = FakeTask.rollup()
     assert [today] == roll1
     assert [yesterday] == roll2
     assert [yesterday] == roll3
@@ -69,7 +80,7 @@ defmodule Castle.RollupTaskTest do
     this_month = Timex.now |> Timex.beginning_of_month |> Timex.to_date
     last_month = Timex.shift(this_month, months: -1)
     prev_month = Timex.shift(this_month, months: -2)
-    rolls = MonthlyTask.do_rollup [count: 3], fn(log) -> log.date end
+    rolls = MonthlyTask.rollup(count: 3)
     assert length(rolls) == 3
     assert Enum.at(rolls, 0) == this_month
     assert Enum.at(rolls, 1) == last_month

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -21,7 +21,7 @@ defmodule Castle.DataCase do
       import Ecto
       import Ecto.Changeset
       import Ecto.Query
-      import Castle.Repo
+      import Castle.Repo, except: [query: 1]
       import Castle.DataCase
     end
   end


### PR DESCRIPTION
🚧WIP

Our current scheme of upsert-the-entire-day produces a lot of dead rows.  Any conflict on unique key is replaced.  And we query every hour for downloads/geos/agents.  So over time ... table and indices get big, and need a `FULL VACUUM` to recover.

UPDATE: not sure this will help very much.  Geo and agent rollups (which are the largest) are done on a daily basis, so there's no way to not upsert everything 24 times a day, if we want our numbers to be up-to-the-hour accurate.