### PR TITLE
Full vacuum cron

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -43,6 +43,7 @@ config :castle, :redis, Castle.Redis.Api
 config :castle, Castle.Scheduler,
   jobs: [
     # {"* * * * *", {Feeder.Sync,         :run, [["--lock"]]}},
+    # {"* * * * *", {Postgres.Vacuum,     :run, [["--lock"]]}},
     # {"* * * * *", {Rollup.Hourly,       :run, [["--lock"]]}},
     # {"* * * * *", {Rollup.Monthly,      :run, [["--lock"]]}},
     # {"* * * * *", {Rollup.Geocountries, :run, [["--lock"]]}},

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -27,13 +27,15 @@ config :castle, :redis, Castle.Redis.Api
 # Scheduled jobs
 config :castle, Castle.Scheduler,
   jobs: [
-    {"* * * * *",     {Feeder.Sync,         :run, [["--lock"]]}},
-    {"15,45 * * * *", {Rollup.Hourly,       :run, [["--lock"]]}},
-    {"15 6 * * *",    {Rollup.Monthly,      :run, [["--lock"]]}},
-    {"20,50 * * * *", {Rollup.Geocountries, :run, [["--lock"]]}},
-    {"25,55 * * * *", {Rollup.Geometros,    :run, [["--lock"]]}},
-    {"30,0 * * * *",  {Rollup.Geosubdivs,   :run, [["--lock"]]}},
-    {"35,5 * * * *",  {Rollup.Agents,       :run, [["--lock"]]}},
+    {"* * * * *",   {Feeder.Sync,     :run, [["--lock"]]}},
+    {"*/5 8 * * *", {Postgres.Vacuum, :run, [["--lock"]]}},
+    # 8-9 UTC reserved for vacuuming rollup tables
+    {"15,45 0-7,9-23 * * *", {Rollup.Hourly,       :run, [["--lock"]]}},
+    {"15 6 * * *",           {Rollup.Monthly,      :run, [["--lock"]]}},
+    {"20,50 0-7,9-23 * * *", {Rollup.Geocountries, :run, [["--lock"]]}},
+    {"25,55 0-7,9-23 * * *", {Rollup.Geometros,    :run, [["--lock"]]}},
+    {"30,0 0-7,9-23 * * *",  {Rollup.Geosubdivs,   :run, [["--lock"]]}},
+    {"35,5 0-7,9-23 * * *",  {Rollup.Agents,       :run, [["--lock"]]}},
   ]
 
 # ## SSL Support

--- a/lib/postgres/bloat.ex
+++ b/lib/postgres/bloat.ex
@@ -1,0 +1,78 @@
+defmodule Postgres.Bloat do
+
+  def estimate(tbl_pattern, min_bloat \\ 0) do
+    filtered = """
+      SELECT tblname, bloat_ratio FROM (#{sql()}) t
+      WHERE tblname ~ $1 AND bloat_ratio > $2
+      LIMIT 1
+    """
+    result = Castle.Repo.query!(filtered, [tbl_pattern, min_bloat])
+    List.flatten(result.rows)
+  end
+
+  # https://github.com/ioguix/pgsql-bloat-estimation/blob/master/table/table_bloat.sql
+  defp sql do
+    """
+      SELECT current_database(), schemaname, tblname, bs*tblpages AS real_size,
+        (tblpages-est_tblpages)*bs AS extra_size,
+        CASE WHEN tblpages - est_tblpages > 0
+          THEN 100 * (tblpages - est_tblpages)/tblpages::float
+          ELSE 0
+        END AS extra_ratio, fillfactor,
+        CASE WHEN tblpages - est_tblpages_ff > 0
+          THEN (tblpages-est_tblpages_ff)*bs
+          ELSE 0
+        END AS bloat_size,
+        CASE WHEN tblpages - est_tblpages_ff > 0
+          THEN 100 * (tblpages - est_tblpages_ff)/tblpages::float
+          ELSE 0
+        END AS bloat_ratio, is_na
+        -- , (pst).free_percent + (pst).dead_tuple_percent AS real_frag
+      FROM (
+        SELECT ceil( reltuples / ( (bs-page_hdr)/tpl_size ) ) + ceil( toasttuples / 4 ) AS est_tblpages,
+          ceil( reltuples / ( (bs-page_hdr)*fillfactor/(tpl_size*100) ) ) + ceil( toasttuples / 4 ) AS est_tblpages_ff,
+          tblpages, fillfactor, bs, tblid, schemaname, tblname, heappages, toastpages, is_na
+          -- , stattuple.pgstattuple(tblid) AS pst
+        FROM (
+          SELECT
+            ( 4 + tpl_hdr_size + tpl_data_size + (2*ma)
+              - CASE WHEN tpl_hdr_size%ma = 0 THEN ma ELSE tpl_hdr_size%ma END
+              - CASE WHEN ceil(tpl_data_size)::int%ma = 0 THEN ma ELSE ceil(tpl_data_size)::int%ma END
+            ) AS tpl_size, bs - page_hdr AS size_per_block, (heappages + toastpages) AS tblpages, heappages,
+            toastpages, reltuples, toasttuples, bs, page_hdr, tblid, schemaname, tblname, fillfactor, is_na
+          FROM (
+            SELECT
+              tbl.oid AS tblid, ns.nspname AS schemaname, tbl.relname AS tblname, tbl.reltuples,
+              tbl.relpages AS heappages, coalesce(toast.relpages, 0) AS toastpages,
+              coalesce(toast.reltuples, 0) AS toasttuples,
+              coalesce(substring(
+                array_to_string(tbl.reloptions, ' ')
+                FROM 'fillfactor=([0-9]+)')::smallint, 100) AS fillfactor,
+              current_setting('block_size')::numeric AS bs,
+              CASE WHEN version()~'mingw32' OR version()~'64-bit|x86_64|ppc64|ia64|amd64' THEN 8 ELSE 4 END AS ma,
+              24 AS page_hdr,
+              23 + CASE WHEN MAX(coalesce(null_frac,0)) > 0 THEN ( 7 + count(*) ) / 8 ELSE 0::int END
+                + CASE WHEN tbl.relhasoids THEN 4 ELSE 0 END AS tpl_hdr_size,
+              sum( (1-coalesce(s.null_frac, 0)) * coalesce(s.avg_width, 1024) ) AS tpl_data_size,
+              bool_or(att.atttypid = 'pg_catalog.name'::regtype)
+                OR count(att.attname) <> count(s.attname) AS is_na
+            FROM pg_attribute AS att
+              JOIN pg_class AS tbl ON att.attrelid = tbl.oid
+              JOIN pg_namespace AS ns ON ns.oid = tbl.relnamespace
+              LEFT JOIN pg_stats AS s ON s.schemaname=ns.nspname
+                AND s.tablename = tbl.relname AND s.inherited=false AND s.attname=att.attname
+              LEFT JOIN pg_class AS toast ON tbl.reltoastrelid = toast.oid
+            WHERE att.attnum > 0 AND NOT att.attisdropped
+              AND tbl.relkind = 'r'
+            GROUP BY 1,2,3,4,5,6,7,8,9,10, tbl.relhasoids
+            ORDER BY 2,3
+          ) AS s
+        ) AS s2
+      ) AS s3
+      -- WHERE NOT is_na
+      --   AND tblpages*((pst).free_percent + (pst).dead_tuple_percent)::float4/100 >= 1
+    """
+  end
+
+
+end

--- a/lib/postgres/tasks/vacuum.ex
+++ b/lib/postgres/tasks/vacuum.ex
@@ -1,0 +1,67 @@
+defmodule Mix.Tasks.Postgres.Vacuum do
+  use Mix.Task
+  require Logger
+  import Castle.Redis.Lock
+
+  @shortdoc "Run a full vacuum on postgres rollup tables"
+
+  @lock "lock.postgres.vacuum"
+  @lock_ttl 50
+  @success_ttl 10
+
+  # TODO: not sure why these are so different
+  @daily_bloat_threshold 1.0
+  @hourly_bloat_threshold 15.0
+
+  def run(args) do
+    {opts, _, _} = OptionParser.parse args,
+      switches: [lock: :boolean, table: :string],
+      aliases: [l: :lock, t: :table]
+
+    if opts[:lock] do
+      {:ok, _started} = Application.ensure_all_started(:castle)
+    else
+      Mix.Ecto.ensure_started(Castle.Repo, [])
+    end
+
+    tbl = opts[:table] || get_worst_table()
+    if tbl do
+      if opts[:lock] do
+        lock @lock, @lock_ttl, @success_ttl, do: full_vacuum(tbl)
+      else
+        full_vacuum(tbl)
+      end
+    end
+  end
+
+  defp get_worst_table do
+    worst_daily = Postgres.Bloat.estimate("^daily.+_20[0-9]{4}", @daily_bloat_threshold)
+    worst_hourly = Postgres.Bloat.estimate("^hourly.+_20[0-9]{4}", @hourly_bloat_threshold)
+    case {worst_daily, worst_hourly} do
+      {[tbl, _ratio], _} -> tbl
+      {_, [tbl, _ratio]} -> tbl
+      _ -> nil
+    end
+  end
+
+  defp full_vacuum(tbl) do
+    start = bloat_ratio(tbl)
+    Logger.info "Postgres.Vacuum.#{tbl} starting (#{start} bloat ratio)"
+
+    Castle.Repo.query! "VACUUM FULL #{tbl}"
+
+    complete = bloat_ratio(tbl)
+    Logger.info "Postgres.Vacuum.#{tbl} complete (#{complete} bloat ratio)"
+    if tbl =~ ~r/^daily/ && complete >= @daily_bloat_threshold do
+      Logger.warn("Postgres.Vacuum.#{tbl} failed to fall below daily threshold")
+    end
+    if tbl =~ ~r/^hourly/ && complete >= @hourly_bloat_threshold do
+      Logger.warn("Postgres.Vacuum.#{tbl} failed to fall below hourly threshold")
+    end
+  end
+
+  defp bloat_ratio(tbl) do
+    [_tbl, ratio] = Postgres.Bloat.estimate(tbl)
+    ratio
+  end
+end


### PR DESCRIPTION
For PRX/internal#380

The Postgres upserts we do on the rollup tables cause quite a bit of bloat.  And even when the dead rows are recovered in the `pg_stat_user_tables.n_dead_tup` table, that doesn't mean the storage was recovered.

There are several ways to estimate table bloat (see [this post](https://www.cybertec-postgresql.com/en/estimating-table-bloat/)).  I landed on using a fairly complex pure SQL route, instead of attempting to install a 3rd party extension in RDS.  It finds the "most bloated" tables and runs a full vacuum on them.

Note that for some reason, the thresholds in prod for the daily vs hourly tables are quite different.  Will keep monitoring this to see if the settings I have actually work:
![image](https://user-images.githubusercontent.com/1410587/50706546-679cc700-101b-11e9-9e96-5dee1d3c155e.png)

I setup the prod cron to run this every 5 minutes between 8-9 UTC.  So for that period of time every day, Metrics/Castle will have stale data.  (Well, the hourly_downloads will still be up to date due to the redis cache - but the other rollups will be behind).