### PR TITLE
Page results for rollups

### DIFF
--- a/lib/big_query/base/query.ex
+++ b/lib/big_query/base/query.ex
@@ -12,7 +12,7 @@ defmodule BigQuery.Base.Query do
   end
 
   def query_each(sql, func), do: query_each(%{}, sql, func)
-  def query_each(params, sql, func), do: query_each(params, sql, func, nil)
+  def query_each(params, sql, func), do: query_each(params, sql, nil, func)
   def query_each(params, sql, limit, func) do
     sql
     |> post_params(params, limit)

--- a/lib/big_query/base/query.ex
+++ b/lib/big_query/base/query.ex
@@ -11,6 +11,16 @@ defmodule BigQuery.Base.Query do
     run_query(queryParams, sql, pageLimit)
   end
 
+  def query_each(sql, func), do: query_each(%{}, sql, func)
+  def query_each(params, sql, func), do: query_each(params, sql, func, nil)
+  def query_each(params, sql, limit, func) do
+    sql
+    |> post_params(params, limit)
+    |> post("queries")
+    |> page_result(func)
+    |> parse_meta()
+  end
+
   defp run_query(queryParams, sql, pageLimit) do
     sql
     |> post_params(queryParams, pageLimit)
@@ -46,6 +56,16 @@ defmodule BigQuery.Base.Query do
     |> page_result()
   end
   defp page_result(data) do
+    data
+  end
+  defp page_result(%{"pageToken" => token, "jobReference" => %{"jobId" => job}} = data, func) do
+    data |> parse_data() |> func.()
+    %{"pageToken" => token}
+    |> get("queries/#{job}")
+    |> page_result(func)
+  end
+  defp page_result(data, func) do
+    data |> parse_data() |> func.()
     data
   end
 

--- a/lib/big_query/base/query_result.ex
+++ b/lib/big_query/base/query_result.ex
@@ -50,7 +50,7 @@ defmodule BigQuery.Base.QueryResult do
         num = if String.contains?(value, "E"),
           do: String.to_float(value) |> round,
           else: String.to_integer(value)
-        {:ok, dtim} = DateTime.from_unix(num)
+        {:ok, dtim} = DateTime.from_unix(num, :second)
         dtim
       {"RECORD", %{"v" => v}} -> parse_value(v, "RECORD")
       {"RECORD", %{"f" => f}} -> parse_value(f, "RECORD")

--- a/lib/big_query/base/query_result.ex
+++ b/lib/big_query/base/query_result.ex
@@ -1,13 +1,14 @@
 defmodule BigQuery.Base.QueryResult do
 
   def from_response(data) do
-    {
-      parse_rows(data["rows"], data["schema"]["fields"]),
-      parse_meta(data),
-    }
+    {parse_data(data), parse_meta(data)}
   end
 
-  defp parse_meta(data) do
+  def parse_data(data) do
+    parse_rows(data["rows"], data["schema"]["fields"])
+  end
+
+  def parse_meta(data) do
     %{
       cached: data |> Map.get("cacheHit", false),
       total: data |> Map.get("totalRows", "0") |> String.to_integer,

--- a/lib/big_query/rollup.ex
+++ b/lib/big_query/rollup.ex
@@ -3,27 +3,27 @@ defmodule BigQuery.Rollup do
   # a day isn't "complete" until this many seconds after it's over
   @buffer_seconds 900
 
-  defdelegate hourly_downloads(), to: BigQuery.Rollup.HourlyDownloads, as: :query
-  defdelegate hourly_downloads(d), to: BigQuery.Rollup.HourlyDownloads, as: :query
-  defdelegate daily_agents(), to: BigQuery.Rollup.DailyAgents, as: :query
-  defdelegate daily_agents(d), to: BigQuery.Rollup.DailyAgents, as: :query
-  defdelegate daily_geo_countries(), to: BigQuery.Rollup.DailyGeoCountries, as: :query
-  defdelegate daily_geo_countries(d), to: BigQuery.Rollup.DailyGeoCountries, as: :query
-  defdelegate daily_geo_metros(), to: BigQuery.Rollup.DailyGeoMetros, as: :query
-  defdelegate daily_geo_metros(d), to: BigQuery.Rollup.DailyGeoMetros, as: :query
-  defdelegate daily_geo_subdivs(), to: BigQuery.Rollup.DailyGeoSubdivs, as: :query
-  defdelegate daily_geo_subdivs(d), to: BigQuery.Rollup.DailyGeoSubdivs, as: :query
+  defdelegate hourly_downloads(func), to: BigQuery.Rollup.HourlyDownloads, as: :query
+  defdelegate hourly_downloads(d, func), to: BigQuery.Rollup.HourlyDownloads, as: :query
+  defdelegate daily_agents(func), to: BigQuery.Rollup.DailyAgents, as: :query
+  defdelegate daily_agents(d, func), to: BigQuery.Rollup.DailyAgents, as: :query
+  defdelegate daily_geo_countries(func), to: BigQuery.Rollup.DailyGeoCountries, as: :query
+  defdelegate daily_geo_countries(d, func), to: BigQuery.Rollup.DailyGeoCountries, as: :query
+  defdelegate daily_geo_metros(func), to: BigQuery.Rollup.DailyGeoMetros, as: :query
+  defdelegate daily_geo_metros(d, func), to: BigQuery.Rollup.DailyGeoMetros, as: :query
+  defdelegate daily_geo_subdivs(func), to: BigQuery.Rollup.DailyGeoSubdivs, as: :query
+  defdelegate daily_geo_subdivs(d, func), to: BigQuery.Rollup.DailyGeoSubdivs, as: :query
 
   def for_day(dtim, query_fn) do
     now = Timex.now()
     day = Timex.beginning_of_day(dtim)
     case completion_state(day, now) do
       :none ->
-        {[], %{day: day, complete: false, hours_complete: 0}}
+        %{day: day, complete: false, hours_complete: 0}
       :partial ->
-        query_fn.(day) |> set_meta(:day, day) |> set_meta(:complete, false) |> set_meta(:hours_complete, hours_complete(now))
+        query_fn.(day) |> Map.put(:day, day) |> Map.put(:complete, false) |> Map.put(:hours_complete, hours_complete(now))
       :complete ->
-        query_fn.(day) |> set_meta(:day, day) |> set_meta(:complete, true)
+        query_fn.(day) |> Map.put(:day, day) |> Map.put(:complete, true)
     end
   end
 
@@ -39,8 +39,4 @@ defmodule BigQuery.Rollup do
   end
 
   def hours_complete(now), do: Timex.shift(now, seconds: -@buffer_seconds).hour
-
-  defp set_meta({results, meta}, key, value) do
-    {results, Map.put(meta, key, value)}
-  end
 end

--- a/lib/big_query/rollup/daily_agents.ex
+++ b/lib/big_query/rollup/daily_agents.ex
@@ -1,11 +1,13 @@
 defmodule BigQuery.Rollup.DailyAgents do
   alias BigQuery.Base.Query, as: Query
 
-  def query(), do: query(Timex.now)
-  def query(dtim) do
+  def query(func), do: query(Timex.now, func)
+  def query(dtim, func) do
     BigQuery.Rollup.for_day dtim, fn(day) ->
       {:ok, date_str} = Timex.format(day, "{YYYY}-{0M}-{0D}")
-      Query.query(%{date_str: date_str}, sql()) |> format_results(day)
+      Query.query_each %{date_str: date_str}, sql(), fn(rows) ->
+        format_results(rows, day) |> func.()
+      end
     end
   end
 
@@ -25,9 +27,9 @@ defmodule BigQuery.Rollup.DailyAgents do
     """
   end
 
-  defp format_results({rows, meta}, from) do
+  defp format_results(rows, from) do
     day = Timex.beginning_of_day(from) |> Timex.to_date()
-    {Enum.map(rows, &(format_result(&1, day))), meta}
+    Enum.map(rows, &(format_result(&1, day)))
   end
 
   defp format_result(row, day) do

--- a/lib/big_query/rollup/daily_geo_countries.ex
+++ b/lib/big_query/rollup/daily_geo_countries.ex
@@ -1,11 +1,13 @@
 defmodule BigQuery.Rollup.DailyGeoCountries do
   alias BigQuery.Base.Query, as: Query
 
-  def query(), do: query(Timex.now)
-  def query(dtim) do
+  def query(func), do: query(Timex.now, func)
+  def query(dtim, func) do
     BigQuery.Rollup.for_day dtim, fn(day) ->
       {:ok, date_str} = Timex.format(day, "{YYYY}-{0M}-{0D}")
-      Query.query(%{date_str: date_str}, sql()) |> format_results(day)
+      Query.query_each %{date_str: date_str}, sql(), fn(rows) ->
+        format_results(rows, day) |> func.()
+      end
     end
   end
 
@@ -24,9 +26,9 @@ defmodule BigQuery.Rollup.DailyGeoCountries do
     """
   end
 
-  defp format_results({rows, meta}, from) do
+  defp format_results(rows, from) do
     day = Timex.beginning_of_day(from) |> Timex.to_date()
-    {Enum.map(rows, &(format_result(&1, day))), meta}
+    Enum.map(rows, &(format_result(&1, day)))
   end
 
   defp format_result(row, day) do

--- a/lib/big_query/rollup/daily_geo_metros.ex
+++ b/lib/big_query/rollup/daily_geo_metros.ex
@@ -1,11 +1,13 @@
 defmodule BigQuery.Rollup.DailyGeoMetros do
   alias BigQuery.Base.Query, as: Query
 
-  def query(), do: query(Timex.now)
-  def query(dtim) do
+  def query(func), do: query(Timex.now, func)
+  def query(dtim, func) do
     BigQuery.Rollup.for_day dtim, fn(day) ->
       {:ok, date_str} = Timex.format(day, "{YYYY}-{0M}-{0D}")
-      Query.query(%{date_str: date_str}, sql()) |> format_results(day)
+      Query.query_each %{date_str: date_str}, sql(), fn(rows) ->
+        format_results(rows, day) |> func.()
+      end
     end
   end
 
@@ -24,9 +26,9 @@ defmodule BigQuery.Rollup.DailyGeoMetros do
     """
   end
 
-  defp format_results({rows, meta}, from) do
+  defp format_results(rows, from) do
     day = Timex.beginning_of_day(from) |> Timex.to_date()
-    {Enum.map(rows, &(format_result(&1, day))), meta}
+    Enum.map(rows, &(format_result(&1, day)))
   end
 
   defp format_result(row, day) do

--- a/lib/castle/bucket/daily.ex
+++ b/lib/castle/bucket/daily.ex
@@ -12,7 +12,7 @@ defmodule Castle.Bucket.Daily do
   end
 
   def ceiling(time) do
-    if Timex.compare(floor(time), time) == 0 do
+    if Timex.compare(__MODULE__.floor(time), time) == 0 do
       time
     else
       Timex.beginning_of_day(time) |> Timex.shift(days: 1)
@@ -24,7 +24,7 @@ defmodule Castle.Bucket.Daily do
   end
 
   def range(from, to) do
-    range(floor(from), ceiling(to), [])
+    range(__MODULE__.floor(from), ceiling(to), [])
   end
   def range(from, to, acc) do
     if Timex.compare(from, to) >= 0 do
@@ -35,7 +35,7 @@ defmodule Castle.Bucket.Daily do
   end
 
   def count_range(from, to) do
-    start = floor(from) |> Timex.to_unix()
+    start = __MODULE__.floor(from) |> Timex.to_unix()
     stop = ceiling(to) |> Timex.to_unix()
     Float.ceil(max(stop - start, 0) / 86400) |> round
   end

--- a/lib/castle/bucket/hourly.ex
+++ b/lib/castle/bucket/hourly.ex
@@ -22,7 +22,7 @@ defmodule Castle.Bucket.Hourly do
   end
 
   def range(from, to) do
-    range(floor(from), ceiling(to), [])
+    range(__MODULE__.floor(from), ceiling(to), [])
   end
   def range(from, to, acc) do
     if Timex.compare(from, to) >= 0 do
@@ -33,7 +33,7 @@ defmodule Castle.Bucket.Hourly do
   end
 
   def count_range(from, to) do
-    start = floor(from) |> Timex.to_unix()
+    start = __MODULE__.floor(from) |> Timex.to_unix()
     stop = ceiling(to) |> Timex.to_unix()
     Float.ceil(max(stop - start, 0) / 3600) |> round
   end

--- a/lib/castle/bucket/hourly.ex
+++ b/lib/castle/bucket/hourly.ex
@@ -9,12 +9,12 @@ defmodule Castle.Bucket.Hourly do
 
   def floor(time) do
     seconds = Timex.to_unix(time)
-    Timex.from_unix(seconds - rem(seconds, 3600))
+    Timex.from_unix(seconds - rem(seconds, 3600), :second)
   end
 
   def ceiling(time) do
     seconds = Timex.to_unix(time)
-    Timex.from_unix(round(Float.ceil(seconds / 3600) * 3600))
+    Timex.from_unix(round(Float.ceil(seconds / 3600) * 3600), :second)
   end
 
   def next(time) do

--- a/lib/castle/bucket/monthly.ex
+++ b/lib/castle/bucket/monthly.ex
@@ -12,7 +12,7 @@ defmodule Castle.Bucket.Monthly do
   end
 
   def ceiling(time) do
-    if Timex.compare(floor(time), time) == 0 do
+    if Timex.compare(__MODULE__.floor(time), time) == 0 do
       time
     else
       Timex.beginning_of_month(time) |> Timex.shift(months: 1)
@@ -24,7 +24,7 @@ defmodule Castle.Bucket.Monthly do
   end
 
   def range(from, to) do
-    range(floor(from), ceiling(to), [])
+    range(__MODULE__.floor(from), ceiling(to), [])
   end
   def range(from, to, acc) do
     if Timex.compare(from, to) >= 0 do
@@ -36,7 +36,7 @@ defmodule Castle.Bucket.Monthly do
 
   # this is an estimate, since days-per-month varies
   def count_range(from, to) do
-    start = floor(from) |> Timex.to_unix()
+    start = __MODULE__.floor(from) |> Timex.to_unix()
     stop = ceiling(to) |> Timex.to_unix()
     Float.ceil(max(stop - start, 0) / 2592000) |> round
   end

--- a/lib/castle/bucket/weekly.ex
+++ b/lib/castle/bucket/weekly.ex
@@ -12,7 +12,7 @@ defmodule Castle.Bucket.Weekly do
   end
 
   def ceiling(time) do
-    if Timex.compare(floor(time), time) == 0 do
+    if Timex.compare(__MODULE__.floor(time), time) == 0 do
       time
     else
       Timex.beginning_of_week(time, 7) |> Timex.shift(weeks: 1)
@@ -24,7 +24,7 @@ defmodule Castle.Bucket.Weekly do
   end
 
   def range(from, to) do
-    range(floor(from), ceiling(to), [])
+    range(__MODULE__.floor(from), ceiling(to), [])
   end
   def range(from, to, acc) do
     if Timex.compare(from, to) >= 0 do
@@ -35,7 +35,7 @@ defmodule Castle.Bucket.Weekly do
   end
 
   def count_range(from, to) do
-    start = floor(from) |> Timex.to_unix()
+    start = __MODULE__.floor(from) |> Timex.to_unix()
     stop = ceiling(to) |> Timex.to_unix()
     Float.ceil(max(stop - start, 0) / 604800) |> round
   end

--- a/lib/rollup/tasks/geocountries.ex
+++ b/lib/rollup/tasks/geocountries.ex
@@ -18,16 +18,19 @@ defmodule Mix.Tasks.Castle.Rollup.Geocountries do
 
   def rollup(rollup_log) do
     Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} querying"
-    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.daily_geo_countries()
-    Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} upserting #{length(results)}"
-    Castle.DailyGeoCountry.upsert_all(results)
+
+    meta = BigQuery.Rollup.daily_geo_countries(rollup_log.date, fn(results) ->
+      Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} upserting #{length(results)}"
+      Castle.DailyGeoCountry.upsert_all(results)
+    end)
+
     case meta do
-      %{complete: true} ->
+      %{complete: true, total: total} ->
         set_complete(rollup_log)
-        Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} complete"
-      %{complete: false, hours_complete: h} ->
+        Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} complete #{total}"
+      %{complete: false, total: total, hours_complete: h} ->
         set_incomplete(rollup_log)
-        Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} incomplete (#{h}/24 hours)"
+        Logger.info "Rollup.DailyGeoCountry.#{rollup_log.date} incomplete #{total} (#{h}/24 hours)"
     end
   end
 end

--- a/lib/rollup/tasks/geosubdivs.ex
+++ b/lib/rollup/tasks/geosubdivs.ex
@@ -18,16 +18,19 @@ defmodule Mix.Tasks.Castle.Rollup.Geosubdivs do
 
   def rollup(rollup_log) do
     Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} querying"
-    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.daily_geo_subdivs()
-    Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} upserting #{length(results)}"
-    Castle.DailyGeoSubdiv.upsert_all(results)
+
+    meta = BigQuery.Rollup.daily_geo_subdivs(rollup_log.date, fn(results) ->
+      Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} upserting #{length(results)}"
+      Castle.DailyGeoSubdiv.upsert_all(results)
+    end)
+
     case meta do
-      %{complete: true} ->
+      %{complete: true, total: total} ->
         set_complete(rollup_log)
-        Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} complete"
-      %{complete: false, hours_complete: h} ->
+        Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} complete #{total}"
+      %{complete: false, total: total, hours_complete: h} ->
         set_incomplete(rollup_log)
-        Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} incomplete (#{h}/24 hours)"
+        Logger.info "Rollup.DailyGeoSubdiv.#{rollup_log.date} incomplete #{total} (#{h}/24 hours)"
     end
   end
 end

--- a/lib/rollup/tasks/hourly.ex
+++ b/lib/rollup/tasks/hourly.ex
@@ -17,17 +17,20 @@ defmodule Mix.Tasks.Castle.Rollup.Hourly do
   end
 
   def rollup(rollup_log) do
-    Logger.info "Rollup.HourlyDownloads.#{rollup_log.date} querying"
-    {results, meta} = rollup_log.date |> Timex.to_datetime() |> BigQuery.Rollup.hourly_downloads()
-    Logger.info "Rollup.HourlyDownloads.#{rollup_log.date} upserting #{length(results)}"
-    Castle.HourlyDownload.upsert_all(results)
+    Logger.info "Rollup.HourlyDownload.#{rollup_log.date} querying"
+
+    meta = BigQuery.Rollup.hourly_downloads(rollup_log.date, fn(results) ->
+      Logger.info "Rollup.HourlyDownload.#{rollup_log.date} upserting #{length(results)}"
+      Castle.HourlyDownload.upsert_all(results)
+    end)
+
     case meta do
-      %{complete: true} ->
+      %{complete: true, total: total} ->
         set_complete(rollup_log)
-        Logger.info "Rollup.HourlyDownloads.#{rollup_log.date} complete"
-      %{complete: false, hours_complete: h} ->
+        Logger.info "Rollup.HourlyDownload.#{rollup_log.date} complete #{total}"
+      %{complete: false, total: total, hours_complete: h} ->
         set_incomplete(rollup_log)
-        Logger.info "Rollup.HourlyDownloads.#{rollup_log.date} incomplete (#{h}/24 hours)"
+        Logger.info "Rollup.HourlyDownload.#{rollup_log.date} incomplete #{total} (#{h}/24 hours)"
     end
   end
 end

--- a/test/big_query/base/query_test.exs
+++ b/test/big_query/base/query_test.exs
@@ -56,4 +56,33 @@ defmodule Castle.BigQueryBaseQueryTest do
     assert meta.megabytes >= 0
     assert meta.total == 215
   end
+
+  @tag :external
+  test "processes each page of results" do
+    sql = """
+      SELECT request_uuid, timestamp, is_duplicate FROM dt_downloads
+      WHERE is_duplicate = @is_dup
+      AND EXTRACT(DATE FROM timestamp) = '2017-10-29'
+      LIMIT @lim
+    """
+    handler = fn(result) ->
+      assert is_list result
+      if length(result) < 100 do
+        assert length(result) == 15
+      else
+        assert length(result) == 100
+      end
+      [{_key, count}] = :ets.lookup(:query_test, :count)
+      :ets.insert(:query_test, {:count, count + length(result)})
+    end
+
+    :ets.new(:query_test, [:set, :public, :named_table])
+    :ets.insert(:query_test, {:count, 0})
+    meta = query_each(%{is_dup: true, lim: 215}, sql, 100, handler)
+
+    assert meta.bytes >= 0
+    assert meta.megabytes >= 0
+    assert meta.total == 215
+    assert :ets.lookup(:query_test, :count) == [count: 215]
+  end
 end

--- a/test/big_query/rollup/daily_agents_test.exs
+++ b/test/big_query/rollup/daily_agents_test.exs
@@ -1,0 +1,52 @@
+defmodule Castle.BigQueryRollupDailyAgentsTest do
+  use Castle.BigQueryCase
+
+  import BigQuery.Rollup.DailyAgents
+
+  test_with_bq "gets empty agents in the past", [] do
+    meta = query get_dtim("2016-01-01T05:04:00Z"), fn(results) ->
+      assert length(results) == 0
+    end
+    assert_time meta.day, "2016-01-01T00:00:00Z"
+    assert meta.complete == true
+  end
+
+  test "gets empty agents in the future" do
+    meta = query get_dtim("2030-01-01"), fn(results) ->
+      assert length(results) == 0
+    end
+    assert_time meta.day, "2030-01-01T00:00:00Z"
+    assert meta.complete == false
+    assert meta.hours_complete == 0
+  end
+
+  test_with_bq "gets a partial day of agents", "2017-05-01T05:14:37Z", [
+    %{podcast_id: 1, episode_id: "a", agent_name_id: 1, agent_type_id: 2, agent_os_id: 3, count: 123},
+    %{podcast_id: 2, episode_id: "b", agent_name_id: 1, agent_type_id: 2, agent_os_id: 3, count: 456},
+    %{podcast_id: 1, episode_id: "a", agent_name_id: 1, agent_type_id: 2, agent_os_id: 3, count: 789},
+  ] do
+    meta = query get_dtim("2017-05-01"), fn(results) ->
+      assert length(results) == 3
+      assert hd(results).podcast_id == 1
+      assert hd(results).episode_id == "a"
+      assert hd(results).agent_name_id == 1
+      assert hd(results).agent_type_id == 2
+      assert hd(results).agent_os_id == 3
+      assert hd(results).count == 123
+      assert hd(results).day == ~D[2017-05-01]
+    end
+    assert_time meta.day, "2017-05-01T00:00:00Z"
+    assert meta.complete == false
+    assert meta.hours_complete == 4
+  end
+
+  @tag :external
+  test "actually gets data" do
+    meta = query get_dtim("2017-05-01"), fn(results) ->
+      assert length(results) == 1311
+      assert hd(results).day == ~D[2017-05-01]
+    end
+    assert_time meta.day, "2017-05-01T00:00:00Z"
+    assert meta.complete == true
+  end
+end

--- a/test/big_query/rollup/daily_geo_countries_test.exs
+++ b/test/big_query/rollup/daily_geo_countries_test.exs
@@ -4,15 +4,17 @@ defmodule Castle.BigQueryRollupDailyGeoCountriesTest do
   import BigQuery.Rollup.DailyGeoCountries
 
   test_with_bq "gets empty geo countries in the past", [] do
-    {results, meta} = query(get_dtim("2016-01-01T05:04:00Z"))
-    assert length(results) == 0
+    meta = query get_dtim("2016-01-01T05:04:00Z"), fn(results) ->
+      assert length(results) == 0
+    end
     assert_time meta.day, "2016-01-01T00:00:00Z"
     assert meta.complete == true
   end
 
   test "gets empty geo countries in the future" do
-    {results, meta} = query(get_dtim("2030-01-01"))
-    assert length(results) == 0
+    meta = query get_dtim("2030-01-01"), fn(results) ->
+      assert length(results) == 0
+    end
     assert_time meta.day, "2030-01-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 0
@@ -23,24 +25,26 @@ defmodule Castle.BigQueryRollupDailyGeoCountriesTest do
     %{podcast_id: 2, episode_id: "b", country_iso_code: "US", count: 456},
     %{podcast_id: 1, episode_id: "a", country_iso_code: "US", count: 789},
   ] do
-    {results, meta} = query(get_dtim("2017-05-01"))
-    assert length(results) == 3
+    meta = query get_dtim("2017-05-01"), fn(results) ->
+      assert length(results) == 3
+      assert hd(results).podcast_id == 1
+      assert hd(results).episode_id == "a"
+      assert hd(results).country_iso_code == "US"
+      assert hd(results).count == 123
+      assert hd(results).day == ~D[2017-05-01]
+    end
     assert_time meta.day, "2017-05-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 4
-    assert hd(results).podcast_id == 1
-    assert hd(results).episode_id == "a"
-    assert hd(results).country_iso_code == "US"
-    assert hd(results).count == 123
-    assert hd(results).day == ~D[2017-05-01]
   end
 
   @tag :external
   test "actually gets data" do
-    {results, meta} = query(get_dtim("2017-05-01"))
-    assert length(results) == 20762
+    meta = query get_dtim("2017-05-01"), fn(results) ->
+      assert length(results) == 20762
+      assert hd(results).day == ~D[2017-05-01]
+    end
     assert_time meta.day, "2017-05-01T00:00:00Z"
     assert meta.complete == true
-    assert hd(results).day == ~D[2017-05-01]
   end
 end

--- a/test/big_query/rollup/daily_geo_metros_test.exs
+++ b/test/big_query/rollup/daily_geo_metros_test.exs
@@ -4,15 +4,17 @@ defmodule Castle.BigQueryRollupDailyGeoMetrosTest do
   import BigQuery.Rollup.DailyGeoMetros
 
   test_with_bq "gets empty geo metros in the past", [] do
-    {results, meta} = query(get_dtim("2016-01-01T05:04:00Z"))
-    assert length(results) == 0
+    meta = query get_dtim("2016-01-01T05:04:00Z"), fn(results) ->
+      assert length(results) == 0
+    end
     assert_time meta.day, "2016-01-01T00:00:00Z"
     assert meta.complete == true
   end
 
   test "gets empty geo metros in the future" do
-    {results, meta} = query(get_dtim("2030-01-01"))
-    assert length(results) == 0
+    meta = query get_dtim("2030-01-01"), fn(results) ->
+      assert length(results) == 0
+    end
     assert_time meta.day, "2030-01-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 0
@@ -23,25 +25,27 @@ defmodule Castle.BigQueryRollupDailyGeoMetrosTest do
     %{podcast_id: 2, episode_id: "b", metro_code: 8888, count: 456},
     %{podcast_id: 1, episode_id: "a", metro_code: 7777, count: 789},
   ] do
-    {results, meta} = query(get_dtim("2017-05-01"))
-    assert length(results) == 3
+    meta = query get_dtim("2017-05-01"), fn(results) ->
+      assert length(results) == 3
+      assert hd(results).podcast_id == 1
+      assert hd(results).episode_id == "a"
+      assert hd(results).metro_code == 9999
+      assert hd(results).count == 123
+      assert hd(results).day == ~D[2017-05-01]
+    end
     assert_time meta.day, "2017-05-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 4
-    assert hd(results).podcast_id == 1
-    assert hd(results).episode_id == "a"
-    assert hd(results).metro_code == 9999
-    assert hd(results).count == 123
-    assert hd(results).day == ~D[2017-05-01]
   end
 
   @tag :external
   test "actually gets data" do
-    {results, meta} = query(get_dtim("2017-05-01"))
-    assert length(results) == 48440
+    meta = query get_dtim("2017-05-01"), fn(results) ->
+      assert length(results) == 48440
+      assert hd(results).day == ~D[2017-05-01]
+      assert hd(results).metro_code > 0
+    end
     assert_time meta.day, "2017-05-01T00:00:00Z"
     assert meta.complete == true
-    assert hd(results).day == ~D[2017-05-01]
-    assert hd(results).metro_code > 0
   end
 end

--- a/test/big_query/rollup/daily_geo_subdivs_test.exs
+++ b/test/big_query/rollup/daily_geo_subdivs_test.exs
@@ -4,15 +4,17 @@ defmodule Castle.BigQueryRollupDailyGeoSubdivsTest do
   import BigQuery.Rollup.DailyGeoSubdivs
 
   test_with_bq "gets empty geo subdivs in the past", [] do
-    {results, meta} = query(get_dtim("2016-01-01T05:04:00Z"))
-    assert length(results) == 0
+    meta = query get_dtim("2016-01-01T05:04:00Z"), fn(results) ->
+      assert length(results) == 0
+    end
     assert_time meta.day, "2016-01-01T00:00:00Z"
     assert meta.complete == true
   end
 
   test "gets empty geo subdivs in the future" do
-    {results, meta} = query(get_dtim("2030-01-01"))
-    assert length(results) == 0
+    meta = query get_dtim("2030-01-01"), fn(results) ->
+      assert length(results) == 0
+    end
     assert_time meta.day, "2030-01-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 0
@@ -23,26 +25,28 @@ defmodule Castle.BigQueryRollupDailyGeoSubdivsTest do
     %{podcast_id: 2, episode_id: "b", country_iso_code: "US", subdivision_1_iso_code: "MN", count: 456},
     %{podcast_id: 1, episode_id: "a", country_iso_code: "US", subdivision_1_iso_code: "MN", count: 789},
   ] do
-    {results, meta} = query(get_dtim("2017-05-01"))
-    assert length(results) == 3
+    meta = query get_dtim("2017-05-01"), fn(results) ->
+      assert length(results) == 3
+      assert hd(results).podcast_id == 1
+      assert hd(results).episode_id == "a"
+      assert hd(results).country_iso_code == "US"
+      assert hd(results).subdivision_1_iso_code == "MN"
+      assert hd(results).count == 123
+      assert hd(results).day == ~D[2017-05-01]
+    end
     assert_time meta.day, "2017-05-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 4
-    assert hd(results).podcast_id == 1
-    assert hd(results).episode_id == "a"
-    assert hd(results).country_iso_code == "US"
-    assert hd(results).subdivision_1_iso_code == "MN"
-    assert hd(results).count == 123
-    assert hd(results).day == ~D[2017-05-01]
   end
 
   @tag :external
   test "actually gets data" do
-    {results, meta} = query(get_dtim("2017-05-01"))
-    assert length(results) == 48440
+    meta = query get_dtim("2017-05-01"), fn(results) ->
+      assert length(results) == 62960
+      assert hd(results).day == ~D[2017-05-01]
+      assert hd(results).subdivision_1_iso_code == "TAS"
+    end
     assert_time meta.day, "2017-05-01T00:00:00Z"
     assert meta.complete == true
-    assert hd(results).day == ~D[2017-05-01]
-    assert hd(results).metro_code > 0
   end
 end

--- a/test/big_query/rollup/hourly_downloads_test.exs
+++ b/test/big_query/rollup/hourly_downloads_test.exs
@@ -4,15 +4,17 @@ defmodule Castle.BigQueryRollupHourlyDownloadsTest do
   import BigQuery.Rollup.HourlyDownloads
 
   test_with_bq "gets empty hourly downloads in the past", [] do
-    {results, meta} = query(get_dtim("2016-01-01T05:04:00Z"))
-    assert length(results) == 0
+    meta = query get_dtim("2016-01-01T05:04:00Z"), fn(results) ->
+      assert length(results) == 0
+    end
     assert_time meta.day, "2016-01-01T00:00:00Z"
     assert meta.complete == true
   end
 
   test "gets empty hourly downloads in the future" do
-    {results, meta} = query(get_dtim("2030-01-01"))
-    assert length(results) == 0
+    meta = query get_dtim("2030-01-01"), fn(results) ->
+      assert length(results) == 0
+    end
     assert_time meta.day, "2030-01-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 0
@@ -23,25 +25,27 @@ defmodule Castle.BigQueryRollupHourlyDownloadsTest do
     %{podcast_id: 2, episode_id: "b", hour: 6, count: 456},
     %{podcast_id: 1, episode_id: "a", hour: 1, count: 789},
   ] do
-    {results, meta} = query(get_dtim("2017-05-01"))
-    assert length(results) == 3
+    meta = query get_dtim("2017-05-01"), fn(results) ->
+      assert length(results) == 3
+      assert hd(results).podcast_id == 1
+      assert hd(results).episode_id == "a"
+      assert hd(results).count == 123
+      assert_time Enum.at(results, 0).dtim, "2017-05-01T02:00:00Z"
+      assert_time Enum.at(results, 1).dtim, "2017-05-01T06:00:00Z"
+      assert_time Enum.at(results, 2).dtim, "2017-05-01T01:00:00Z"
+    end
     assert_time meta.day, "2017-05-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 4
-    assert hd(results).podcast_id == 1
-    assert hd(results).episode_id == "a"
-    assert hd(results).count == 123
-    assert_time Enum.at(results, 0).dtim, "2017-05-01T02:00:00Z"
-    assert_time Enum.at(results, 1).dtim, "2017-05-01T06:00:00Z"
-    assert_time Enum.at(results, 2).dtim, "2017-05-01T01:00:00Z"
   end
 
   @tag :external
   test "actually gets data" do
-    {results, meta} = query(get_dtim("2017-05-01"))
-    assert length(results) == 24248
+    meta = query get_dtim("2017-05-01"), fn(results) ->
+      assert length(results) == 24248
+      assert format_dtim(hd(results).dtim) =~ ~r/2017-05-01T[0-2][0-9]:00:00/
+    end
     assert_time meta.day, "2017-05-01T00:00:00Z"
     assert meta.complete == true
-    assert format_dtim(hd(results).dtim) =~ ~r/2017-05-01T[0-2][0-9]:00:00/
   end
 end

--- a/test/big_query/rollup_test.exs
+++ b/test/big_query/rollup_test.exs
@@ -4,26 +4,21 @@ defmodule Castle.BigQueryRollupTest do
   import BigQuery.Rollup
 
   test "gets nothing for future days" do
-    {results, meta} = for_day get_dtim("2030-01-01"), fn(_) -> ["nothing"] end
-    assert length(results) == 0
+    meta = for_day get_dtim("2030-01-01"), fn(_) -> ["nothing"] end
     assert_time meta.day, "2030-01-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 0
   end
 
   test_with_bq "gets partial for today", "2017-05-01T15:14:13Z", [] do
-    {results, meta} = for_day Timex.now, fn(_) -> {["something"], %{meta: "data"}} end
-    assert length(results) == 1
-    assert results == ["something"]
+    meta = for_day Timex.now, fn(_) -> %{meta: "data"} end
     assert_time Timex.to_date(meta.day), "2017-05-01T00:00:00Z"
     assert meta.complete == false
     assert meta.hours_complete == 14
   end
 
   test_with_bq "gets complete for the past", "2017-05-01T15:14:13Z", [] do
-    {results, meta} = for_day get_dtim("2017-04-29"), fn(_) -> {["something"], %{meta: "data"}} end
-    assert length(results) == 1
-    assert results == ["something"]
+    meta = for_day get_dtim("2017-04-29"), fn(_) -> %{meta: "data"} end
     assert_time Timex.to_date(meta.day), "2017-04-29T00:00:00Z"
     assert meta.complete == true
   end

--- a/test/castle/bucket/daily_test.exs
+++ b/test/castle/bucket/daily_test.exs
@@ -3,7 +3,7 @@ defmodule Castle.CastleBucketDailyTest do
 
   import Castle.Bucket.Daily
 
-  defp format_floor(str), do: mutate_dtim(str, &floor/1)
+  defp format_floor(str), do: mutate_dtim(str, &Castle.Bucket.Daily.floor/1)
   defp format_ceiling(str), do: mutate_dtim(str, &ceiling/1)
   defp format_next(str), do: mutate_dtim(str, &next/1)
   defp format_range(s1, s2), do: mutate_dtims(s1, s2, &range/2)

--- a/test/castle/bucket/hourly_test.exs
+++ b/test/castle/bucket/hourly_test.exs
@@ -3,7 +3,7 @@ defmodule Castle.CastleBucketHourlyTest do
 
   import Castle.Bucket.Hourly
 
-  defp format_floor(str), do: mutate_dtim(str, &floor/1)
+  defp format_floor(str), do: mutate_dtim(str, &Castle.Bucket.Hourly.floor/1)
   defp format_ceiling(str), do: mutate_dtim(str, &ceiling/1)
   defp format_next(str), do: mutate_dtim(str, &next/1)
   defp format_range(s1, s2), do: mutate_dtims(s1, s2, &range/2)

--- a/test/castle/bucket/monthly_test.exs
+++ b/test/castle/bucket/monthly_test.exs
@@ -3,7 +3,7 @@ defmodule Castle.CastleBucketMonthlyTest do
 
   import Castle.Bucket.Monthly
 
-  defp format_floor(str), do: mutate_dtim(str, &floor/1)
+  defp format_floor(str), do: mutate_dtim(str, &Castle.Bucket.Monthly.floor/1)
   defp format_ceiling(str), do: mutate_dtim(str, &ceiling/1)
   defp format_next(str), do: mutate_dtim(str, &next/1)
   defp format_range(s1, s2), do: mutate_dtims(s1, s2, &range/2)

--- a/test/castle/bucket/weekly_test.exs
+++ b/test/castle/bucket/weekly_test.exs
@@ -3,7 +3,7 @@ defmodule Castle.CastleBucketWeeklyTest do
 
   import Castle.Bucket.Weekly
 
-  defp format_floor(str), do: mutate_dtim(str, &floor/1)
+  defp format_floor(str), do: mutate_dtim(str, &Castle.Bucket.Weekly.floor/1)
   defp format_ceiling(str), do: mutate_dtim(str, &ceiling/1)
   defp format_next(str), do: mutate_dtim(str, &next/1)
   defp format_range(s1, s2), do: mutate_dtims(s1, s2, &range/2)

--- a/test/support/big_query_case.ex
+++ b/test/support/big_query_case.ex
@@ -13,7 +13,12 @@ defmodule Castle.BigQueryCase do
           data = unquote(mock_result)
           {data, %{bytes: 1, megabytes: 1, cached: false, total: length(data)}}
         end
-        with_mock BigQuery.Base.Query, [query: query] do
+        query_each = fn(_params, _sql, func) ->
+          data = unquote(mock_result)
+          func.(data)
+          %{bytes: 1, megabytes: 1, cached: false, total: length(data)}
+        end
+        with_mock BigQuery.Base.Query, [query: query, query_each: query_each] do
           if unquote(now_str) do
             now = [now: fn() -> get_dtim(unquote(now_str)) end]
             with_mock Timex, [:passthrough], now, do: unquote(expression)


### PR DESCRIPTION
For #107.

BigQuery automatically forces a max-bytes of response payload.  Previously, Castle would page through that and collect all of the rows in-memory before returning to the caller.  This resulted in OOM problems with large result sets (geo-subdivs in particular).

This PR upserts each page of BQ results into Postgres before going on to the next page.  From what I've seen, geo-subdiv rollups have 4 or 5 pages.  So should use maybe %75 less memory doing rollups after this.

(Also fixed some soon-to-be-deprecation problems with `Kernel.floor` and `from_unix`)