### PR TITLE
Longer image urls

### DIFF
--- a/priv/repo/migrations/20191217145133_longer_image_urls.exs
+++ b/priv/repo/migrations/20191217145133_longer_image_urls.exs
@@ -1,0 +1,23 @@
+defmodule Castle.Repo.Migrations.LongerImageUrls do
+  use Ecto.Migration
+
+  def up do
+    alter table(:podcasts) do
+      modify(:image_url, :text)
+    end
+
+    alter table(:episodes) do
+      modify(:image_url, :text)
+    end
+  end
+
+  def down do
+    alter table(:podcasts) do
+      modify(:image_url, :string)
+    end
+
+    alter table(:episodes) do
+      modify(:image_url, :string)
+    end
+  end
+end


### PR DESCRIPTION
Half of #114

Hitting the varchar 255 limit on some recently imported episodes.  Change both the podcast/episode image_urls to be text instead.