### PR TITLE
Store feeder episode keywords

### DIFF
--- a/lib/castle/episode.ex
+++ b/lib/castle/episode.ex
@@ -33,7 +33,8 @@ defmodule Castle.Episode do
       :published_at,
       :released_at,
       :segment_count,
-      :audio_version
+      :audio_version,
+      :keywords
     ])
     |> validate_required([:podcast_id])
   end

--- a/lib/castle/episode.ex
+++ b/lib/castle/episode.ex
@@ -17,6 +17,7 @@ defmodule Castle.Episode do
     field(:released_at, :utc_datetime)
     field(:segment_count, :integer)
     field(:audio_version, :string)
+    field(:keywords, {:array, :string})
   end
 
   @doc false
@@ -98,7 +99,8 @@ defmodule Castle.Episode do
       published_at: parse_dtim(doc["publishedAt"]),
       released_at: parse_dtim(doc["releasedAt"]),
       segment_count: doc["segmentCount"],
-      audio_version: doc["audioVersion"]
+      audio_version: doc["audioVersion"],
+      keywords: doc["categories"]
     }
   end
 

--- a/priv/repo/migrations/20200630185355_episodes_have_tags.exs
+++ b/priv/repo/migrations/20200630185355_episodes_have_tags.exs
@@ -3,7 +3,7 @@ defmodule Castle.Repo.Migrations.EpisodesHaveTags do
 
   def change do
     alter table(:episodes) do
-      add(:keywords, {:array, :string})
+      add(:keywords, {:array, :text})
     end
   end
 end

--- a/priv/repo/migrations/20200630185355_episodes_have_tags.exs
+++ b/priv/repo/migrations/20200630185355_episodes_have_tags.exs
@@ -1,0 +1,9 @@
+defmodule Castle.Repo.Migrations.EpisodesHaveTags do
+  use Ecto.Migration
+
+  def change do
+    alter table(:episodes) do
+      add(:keywords, {:array, :string})
+    end
+  end
+end

--- a/test/castle/episode_test.exs
+++ b/test/castle/episode_test.exs
@@ -46,7 +46,11 @@ defmodule Castle.EpisodeTest do
       ],
       "_links" => %{
         "prx:podcast" => %{"href" => "/api/v1/podcasts/123"}
-      }
+      },
+      "categories" => [
+        "some",
+        "tag"
+      ]
     })
 
     assert episode = get(Castle.Episode, @id1)
@@ -60,6 +64,7 @@ defmodule Castle.EpisodeTest do
     assert_time(episode.released_at, "2018-04-25T04:30:01Z")
     assert episode.segment_count == 2
     assert episode.audio_version == "my-version"
+    assert episode.keywords == ["some", "tag"]
   end
 
   test "updates from a feeder doc" do


### PR DESCRIPTION
See: https://github.com/PRX/augury.prx.org/issues/179 
- Pulls feeder keywords in as part of parsing the episode doc during episode sync.
 - Serializes them as an array on the episode model.

Once this is merged, set up the keywords for existing episodes by re-running the episode sync process.