### PR TITLE
Sync feeder deleted at

### DIFF
--- a/lib/castle/episode.ex
+++ b/lib/castle/episode.ex
@@ -64,6 +64,10 @@ defmodule Castle.Episode do
     )
   end
 
+  def undeleted(queryable) do
+    from(r in queryable, where: is_nil(r.deleted_at))
+  end
+
   def total(queryable) do
     Castle.Repo.one(from(r in subquery(queryable), select: count(r.id)))
   end

--- a/lib/castle/episode.ex
+++ b/lib/castle/episode.ex
@@ -13,6 +13,7 @@ defmodule Castle.Episode do
     field(:image_url, :string)
     field(:created_at, :utc_datetime)
     field(:updated_at, :utc_datetime)
+    field(:deleted_at, :utc_datetime)
     field(:published_at, :utc_datetime)
     field(:released_at, :utc_datetime)
     field(:segment_count, :integer)
@@ -30,6 +31,7 @@ defmodule Castle.Episode do
       :image_url,
       :created_at,
       :updated_at,
+      :deleted_at,
       :published_at,
       :released_at,
       :segment_count,
@@ -97,6 +99,7 @@ defmodule Castle.Episode do
       image_url: image_url(doc["images"]),
       created_at: parse_dtim(doc["createdAt"]),
       updated_at: parse_dtim(doc["updatedAt"]),
+      deleted_at: parse_dtim(doc["deletedAt"]),
       published_at: parse_dtim(doc["publishedAt"]),
       released_at: parse_dtim(doc["releasedAt"]),
       segment_count: doc["segmentCount"],

--- a/lib/castle/podcast.ex
+++ b/lib/castle/podcast.ex
@@ -34,6 +34,10 @@ defmodule Castle.Podcast do
     from(p in Castle.Podcast, where: p.account_id in ^accounts, order_by: [asc: :title])
   end
 
+  def undeleted(queryable) do
+    from(r in queryable, where: is_nil(r.deleted_at))
+  end
+
   def total(queryable) do
     Castle.Repo.one(from(r in subquery(queryable), select: count(r.id)))
   end

--- a/lib/castle/podcast.ex
+++ b/lib/castle/podcast.ex
@@ -12,6 +12,7 @@ defmodule Castle.Podcast do
     field(:image_url, :string)
     field(:created_at, :utc_datetime)
     field(:updated_at, :utc_datetime)
+    field(:deleted_at, :utc_datetime)
     field(:published_at, :utc_datetime)
   end
 
@@ -24,6 +25,7 @@ defmodule Castle.Podcast do
       :image_url,
       :created_at,
       :updated_at,
+      :deleted_at,
       :published_at
     ])
   end
@@ -61,6 +63,7 @@ defmodule Castle.Podcast do
       image_url: image_url(doc),
       created_at: parse_dtim(doc["createdAt"]),
       updated_at: parse_dtim(doc["updatedAt"]),
+      deleted_at: parse_dtim(doc["deletedAt"]),
       published_at: parse_dtim(doc["publishedAt"])
     }
   end

--- a/lib/castle/podcast.ex
+++ b/lib/castle/podcast.ex
@@ -6,39 +6,49 @@ defmodule Castle.Podcast do
   @primary_key {:id, :integer, autogenerate: false}
 
   schema "podcasts" do
-    field :account_id, :integer
-    field :title, :string
-    field :subtitle, :string
-    field :image_url, :string
-    field :created_at, :utc_datetime
-    field :updated_at, :utc_datetime
-    field :published_at, :utc_datetime
+    field(:account_id, :integer)
+    field(:title, :string)
+    field(:subtitle, :string)
+    field(:image_url, :string)
+    field(:created_at, :utc_datetime)
+    field(:updated_at, :utc_datetime)
+    field(:published_at, :utc_datetime)
   end
 
   def changeset(podcast, attrs) do
     podcast
-    |> cast(attrs, [:account_id, :title, :subtitle, :image_url, :created_at, :updated_at, :published_at])
+    |> cast(attrs, [
+      :account_id,
+      :title,
+      :subtitle,
+      :image_url,
+      :created_at,
+      :updated_at,
+      :published_at
+    ])
   end
 
   def recent_query(accounts) do
-    from p in Castle.Podcast, where: p.account_id in ^accounts, order_by: [asc: :title]
+    from(p in Castle.Podcast, where: p.account_id in ^accounts, order_by: [asc: :title])
   end
 
   def total(queryable) do
-    Castle.Repo.one(from r in subquery(queryable), select: count(r.id))
+    Castle.Repo.one(from(r in subquery(queryable), select: count(r.id)))
   end
 
   def max_updated_at do
-    Castle.Repo.one(from p in Castle.Podcast, select: max(p.updated_at))
+    Castle.Repo.one(from(p in Castle.Podcast, select: max(p.updated_at)))
   end
 
   def from_feeder(doc) do
-    struct!(Castle.Podcast, parse_feeder(doc)) |> Castle.Repo.insert!
+    struct!(Castle.Podcast, parse_feeder(doc)) |> Castle.Repo.insert!()
   end
+
   def from_feeder(podcast, doc) do
     changes = parse_feeder(doc)
+
     if Timex.compare(changes.updated_at, podcast.updated_at) >= 0 do
-      changeset(podcast, changes) |> Castle.Repo.update!
+      changeset(podcast, changes) |> Castle.Repo.update!()
     end
   end
 
@@ -51,7 +61,7 @@ defmodule Castle.Podcast do
       image_url: image_url(doc),
       created_at: parse_dtim(doc["createdAt"]),
       updated_at: parse_dtim(doc["updatedAt"]),
-      published_at: parse_dtim(doc["publishedAt"]),
+      published_at: parse_dtim(doc["publishedAt"])
     }
   end
 
@@ -63,6 +73,7 @@ defmodule Castle.Podcast do
   defp image_url(_any), do: nil
 
   defp parse_dtim(nil), do: nil
+
   defp parse_dtim(dtim_str) do
     {:ok, dtim} = Timex.parse(dtim_str, "{ISO:Extended:Z}")
     DateTime.truncate(dtim, :second)

--- a/lib/castle_web/controllers/api/episode_controller.ex
+++ b/lib/castle_web/controllers/api/episode_controller.ex
@@ -10,6 +10,7 @@ defmodule CastleWeb.API.EpisodeController do
 
     queryable =
       Castle.Episode.recent_query(podcast.id)
+      |> Castle.Episode.undeleted()
       |> CastleWeb.Search.filter_title_search(search)
 
     total = Castle.Episode.total(queryable)
@@ -25,6 +26,7 @@ defmodule CastleWeb.API.EpisodeController do
 
     queryable =
       Castle.Episode.recent_query(accounts)
+      |> Castle.Episode.undeleted()
       |> CastleWeb.Search.filter_title_search(search)
 
     total = Castle.Episode.total(queryable)

--- a/lib/castle_web/controllers/api/podcast_controller.ex
+++ b/lib/castle_web/controllers/api/podcast_controller.ex
@@ -11,6 +11,7 @@ defmodule CastleWeb.API.PodcastController do
 
     queryable =
       Castle.Podcast.recent_query(accounts)
+      |> Castle.Podcast.undeleted()
       |> CastleWeb.Search.filter_title_search(search)
 
     total = Castle.Podcast.total(queryable)

--- a/priv/repo/migrations/20210625173911_add_feeder_deleted_at.exs
+++ b/priv/repo/migrations/20210625173911_add_feeder_deleted_at.exs
@@ -1,0 +1,13 @@
+defmodule Castle.Repo.Migrations.AddFeederDeletedAt do
+  use Ecto.Migration
+
+  def change do
+    alter table(:podcasts) do
+      add(:deleted_at, :utc_datetime)
+    end
+
+    alter table(:episodes) do
+      add(:deleted_at, :utc_datetime)
+    end
+  end
+end

--- a/test/castle/episode_test.exs
+++ b/test/castle/episode_test.exs
@@ -36,6 +36,7 @@ defmodule Castle.EpisodeTest do
       "subtitle" => "world",
       "createdAt" => "2018-04-25T04:00:00.129Z",
       "updatedAt" => "2018-04-25T05:00:00Z",
+      "deletedAt" => "2018-04-25T05:00:01Z",
       "publishedAt" => "2018-04-25T04:30:00Z",
       "releasedAt" => "2018-04-25T04:30:01Z",
       "segmentCount" => 2,
@@ -60,6 +61,7 @@ defmodule Castle.EpisodeTest do
     assert episode.image_url == "http://foo.bar/image1.jpg"
     assert_time(episode.created_at, "2018-04-25T04:00:00Z")
     assert_time(episode.updated_at, "2018-04-25T05:00:00Z")
+    assert_time(episode.deleted_at, "2018-04-25T05:00:01Z")
     assert_time(episode.published_at, "2018-04-25T04:30:00Z")
     assert_time(episode.released_at, "2018-04-25T04:30:01Z")
     assert episode.segment_count == 2

--- a/test/castle/hourly_download_test.exs
+++ b/test/castle/hourly_download_test.exs
@@ -8,9 +8,10 @@ defmodule Castle.HourlyDownloadTest do
   @guid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
 
   setup do
-    Enum.map list_partitions(), fn(table_name) ->
-      Ecto.Adapters.SQL.query!("DROP TABLE #{table_name}")
-    end
+    Enum.map(list_partitions(), fn table_name ->
+      Ecto.Adapters.SQL.query!("DROP TABLE #{table_name}", [])
+    end)
+
     []
   end
 
@@ -33,10 +34,13 @@ defmodule Castle.HourlyDownloadTest do
   end
 
   defp do_upsert_all(dtim, count), do: do_upsert_all([{dtim, count}])
+
   defp do_upsert_all(rows) when is_list(rows) do
     rows
-      |> Enum.map(fn({dtim, count}) -> %{podcast_id: @id, episode_id: @guid, dtim: get_dtim(dtim), count: count} end)
-      |> upsert_all()
+    |> Enum.map(fn {dtim, count} ->
+      %{podcast_id: @id, episode_id: @guid, dtim: get_dtim(dtim), count: count}
+    end)
+    |> upsert_all()
   end
 
   defp count_partition(month) do
@@ -50,5 +54,4 @@ defmodule Castle.HourlyDownloadTest do
     result = Ecto.Adapters.SQL.query!(Castle.Repo, query, [])
     List.flatten(result.rows)
   end
-
 end

--- a/test/castle/podcast_test.exs
+++ b/test/castle/podcast_test.exs
@@ -23,6 +23,7 @@ defmodule Castle.PodcastTest do
       "subtitle" => "world",
       "createdAt" => "2018-04-25T04:00:00.129Z",
       "updatedAt" => "2018-04-25T05:00:00Z",
+      "deletedAt" => "2018-04-25T05:00:01Z",
       "publishedAt" => "2018-04-25T04:30:00Z",
       "itunesImage" => %{"url" => "http://foo.bar/itunes.jpg"},
       "feedImage" => %{"url" => "http://foo.bar/feed.jpg"}
@@ -35,6 +36,7 @@ defmodule Castle.PodcastTest do
     assert podcast.image_url == "http://foo.bar/feed.jpg"
     assert_time(podcast.created_at, "2018-04-25T04:00:00Z")
     assert_time(podcast.updated_at, "2018-04-25T05:00:00Z")
+    assert_time(podcast.deleted_at, "2018-04-25T05:00:01Z")
     assert_time(podcast.published_at, "2018-04-25T04:30:00Z")
   end
 

--- a/test/castle/podcast_test.exs
+++ b/test/castle/podcast_test.exs
@@ -12,7 +12,7 @@ defmodule Castle.PodcastTest do
     insert!(%Castle.Podcast{id: 1, account_id: 123, updated_at: get_dtim("2018-04-25T04:00:00Z")})
     insert!(%Castle.Podcast{id: 2, account_id: 456, updated_at: get_dtim("2018-04-25T02:00:00Z")})
     insert!(%Castle.Podcast{id: 3, account_id: 123, updated_at: get_dtim("2018-04-25T18:00:00Z")})
-    assert_time max_updated_at(), "2018-04-25T18:00:00Z"
+    assert_time(max_updated_at(), "2018-04-25T18:00:00Z")
   end
 
   test "creates from a feeder doc" do
@@ -25,29 +25,52 @@ defmodule Castle.PodcastTest do
       "updatedAt" => "2018-04-25T05:00:00Z",
       "publishedAt" => "2018-04-25T04:30:00Z",
       "itunesImage" => %{"url" => "http://foo.bar/itunes.jpg"},
-      "feedImage" => %{"url" => "http://foo.bar/feed.jpg"},
+      "feedImage" => %{"url" => "http://foo.bar/feed.jpg"}
     })
+
     assert podcast = get(Castle.Podcast, 123)
     assert podcast.account_id == 456
     assert podcast.title == "hello"
     assert podcast.subtitle == "world"
     assert podcast.image_url == "http://foo.bar/feed.jpg"
-    assert_time podcast.created_at, "2018-04-25T04:00:00Z"
-    assert_time podcast.updated_at, "2018-04-25T05:00:00Z"
-    assert_time podcast.published_at, "2018-04-25T04:30:00Z"
+    assert_time(podcast.created_at, "2018-04-25T04:00:00Z")
+    assert_time(podcast.updated_at, "2018-04-25T05:00:00Z")
+    assert_time(podcast.published_at, "2018-04-25T04:30:00Z")
   end
 
   test "updates from a feeder doc" do
-    original = insert!(%Castle.Podcast{id: 123, title: "hello", updated_at: get_dtim("2018-04-25T04:00:00Z")})
-    from_feeder(original, %{"id" => 123, "title" => "world", "updatedAt" => "2018-04-25T05:00:00Z"})
+    original =
+      insert!(%Castle.Podcast{
+        id: 123,
+        title: "hello",
+        updated_at: get_dtim("2018-04-25T04:00:00Z")
+      })
+
+    from_feeder(original, %{
+      "id" => 123,
+      "title" => "world",
+      "updatedAt" => "2018-04-25T05:00:00Z"
+    })
+
     assert podcast = get(Castle.Podcast, 123)
     assert podcast.title == "world"
-    assert_time podcast.updated_at, "2018-04-25T05:00:00Z"
+    assert_time(podcast.updated_at, "2018-04-25T05:00:00Z")
   end
 
   test "ignores updates with an older timestamp" do
-    original = insert!(%Castle.Podcast{id: 123, title: "hello", updated_at: get_dtim("2018-04-25T04:00:00Z")})
-    from_feeder(original, %{"id" => 123, "title" => "world", "updatedAt" => "2018-04-25T03:00:00Z"})
+    original =
+      insert!(%Castle.Podcast{
+        id: 123,
+        title: "hello",
+        updated_at: get_dtim("2018-04-25T04:00:00Z")
+      })
+
+    from_feeder(original, %{
+      "id" => 123,
+      "title" => "world",
+      "updatedAt" => "2018-04-25T03:00:00Z"
+    })
+
     assert podcast = get(Castle.Podcast, 123)
     assert podcast.title == "hello"
   end
@@ -69,8 +92,11 @@ defmodule Castle.PodcastTest do
     insert!(%Castle.Podcast{id: 1, account_id: 123})
     insert!(%Castle.Podcast{id: 2, account_id: 456})
     insert!(%Castle.Podcast{id: 3, account_id: 123})
-    podcasts = recent_query([123])
-               |> Castle.Repo.all
+
+    podcasts =
+      recent_query([123])
+      |> Castle.Repo.all()
+
     assert length(podcasts) == 2
     assert Enum.at(podcasts, 0).id == 1
     assert Enum.at(podcasts, 1).id == 3
@@ -90,26 +116,23 @@ defmodule Castle.PodcastTest do
     insert!(%Castle.Podcast{id: 2, account_id: 1, subtitle: "test foo jumps over"})
     insert!(%Castle.Podcast{id: 3, account_id: 1, title: "test bar the sleeping dog"})
 
-    assert (recent_query([1])
-    |> CastleWeb.Search.filter_title_search("dog")
-    |> Castle.Repo.all
-    |> Enum.map(fn e -> e.id end)
-    |> Enum.sort
-    ) == [3]
+    assert recent_query([1])
+           |> CastleWeb.Search.filter_title_search("dog")
+           |> Castle.Repo.all()
+           |> Enum.map(fn e -> e.id end)
+           |> Enum.sort() == [3]
 
-    assert (recent_query([1])
-    |> CastleWeb.Search.filter_title_search("test foo")
-    |> Castle.Repo.all
-    |> Enum.map(fn e -> e.id end)
-    |> Enum.sort
-    ) == [1, 2] |> Enum.sort
+    assert recent_query([1])
+           |> CastleWeb.Search.filter_title_search("test foo")
+           |> Castle.Repo.all()
+           |> Enum.map(fn e -> e.id end)
+           |> Enum.sort() == [1, 2] |> Enum.sort()
 
     # prefix search
-    assert (recent_query([1])
-    |> CastleWeb.Search.filter_title_search("j")
-    |> Castle.Repo.all
-    |> Enum.map(fn e -> e.id end)
-    |> Enum.sort
-    ) == [2] |> Enum.sort
+    assert recent_query([1])
+           |> CastleWeb.Search.filter_title_search("j")
+           |> Castle.Repo.all()
+           |> Enum.map(fn e -> e.id end)
+           |> Enum.sort() == [2] |> Enum.sort()
   end
 end

--- a/test/controllers/api/episode_controller_test.exs
+++ b/test/controllers/api/episode_controller_test.exs
@@ -54,6 +54,18 @@ defmodule Castle.API.EpisodeControllerTest do
       assert resp["_links"]["first"]["href"] == "/api/v1/episodes"
     end
 
+    test "hides deleted episodes", %{conn: conn} do
+      Castle.Episode
+      |> Castle.Repo.get(@guid1)
+      |> Castle.Episode.changeset(%{deleted_at: Timex.now()})
+      |> Castle.Repo.update!()
+
+      resp = conn |> get(api_episode_path(conn, :index)) |> json_response(200)
+      assert length(resp["_embedded"]["prx:items"]) == 1
+      assert Enum.at(resp["_embedded"]["prx:items"], 0)["id"] == @guid2
+      assert Enum.at(resp["_embedded"]["prx:items"], 0)["title"] == "two"
+    end
+
     test "allows searching with search, page and per params", %{conn: conn} do
       insert!(%Castle.Episode{
         id: @guid4,

--- a/test/controllers/api/podcast_controller_test.exs
+++ b/test/controllers/api/podcast_controller_test.exs
@@ -31,6 +31,18 @@ defmodule Castle.API.PodcastControllerTest do
       assert Enum.at(resp["_embedded"]["prx:items"], 0)["title"] == "two"
       assert resp["_links"]["first"]["href"] == "/api/v1/podcasts?search=two"
     end
+
+    test "hides deleted podcasts", %{conn: conn} do
+      Castle.Podcast
+      |> Castle.Repo.get(123)
+      |> Castle.Podcast.changeset(%{deleted_at: Timex.now()})
+      |> Castle.Repo.update!()
+
+      resp = conn |> get(api_podcast_path(conn, :index)) |> json_response(200)
+      assert length(resp["_embedded"]["prx:items"]) == 1
+      assert Enum.at(resp["_embedded"]["prx:items"], 0)["id"] == 456
+      assert Enum.at(resp["_embedded"]["prx:items"], 0)["title"] == "two"
+    end
   end
 
   describe "show/2" do


### PR DESCRIPTION
Syncs Feeder `podcasts.deleted_at` and `episodes.deleted_at` to the Augury database.

**NOTE:** this will take a `mix feeder.sync --all --force` to get all the deleted stuff we've already missed (we've passed by their `updated_at` timestamps).

**WHICH MEANS:** that will likely pull in a lot of surprising/deleted stuff into the Metrics UI.  So I did end up hiding deleted podcasts/episodes in the API index endpoints for now.  But we should revisit if that's the right choice.
