### PR TITLE
Remove deprecated columns

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,4 @@
 [
   import_deps: [:phoenix],
-  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["*.{ex,exs}", "{config,lib,priv,test}/**/*.{ex,exs}"]
 ]

--- a/lib/big_query/base/query.ex
+++ b/lib/big_query/base/query.ex
@@ -18,7 +18,7 @@ defmodule BigQuery.Base.Query do
 
   # also log the sql + metadata
   def log(str, params \\ %{}, pageLimit \\ nil) do
-    IO.puts("  #{String.replace(str, ~r/\s+/, " ")}")
+    IO.puts("  #{String.trim(String.replace(str, ~r/\s+/, " "))}")
     {result, meta} = run_query(params, str, pageLimit)
     IO.puts("  #{inspect(meta)}")
     {result, meta}

--- a/priv/big_query/migrations/20220401201605_remove_deprecated.exs
+++ b/priv/big_query/migrations/20220401201605_remove_deprecated.exs
@@ -1,0 +1,47 @@
+defmodule BigQuery.Migrations.RemoveDeprecated do
+  alias BigQuery.Base.Query
+
+  # all our shows flipped to IAB2 within a few days of this
+  @first_is_bytes ~U[2019-05-22 19:00:00.000Z]
+
+  def up do
+    Query.log("""
+      ALTER TABLE dt_downloads
+      DROP COLUMN program,
+      DROP COLUMN path,
+      DROP COLUMN clienthash,
+      DROP COLUMN postal_code,
+      DROP COLUMN latitude,
+      DROP COLUMN longitude,
+      DROP COLUMN is_bytes,
+      DROP COLUMN listener_session;
+
+      ALTER TABLE dt_impressions
+      DROP COLUMN is_bytes,
+      DROP COLUMN listener_session;
+    """)
+  end
+
+  def down do
+    Query.log(
+      """
+        ALTER TABLE dt_downloads
+        ADD COLUMN program STRING,
+        ADD COLUMN path STRING,
+        ADD COLUMN clienthash STRING,
+        ADD COLUMN postal_code STRING,
+        ADD COLUMN latitude FLOAT64,
+        ADD COLUMN longitude FLOAT64,
+        ADD COLUMN is_bytes BOOL,
+        ADD COLUMN listener_session STRING;
+
+        UPDATE dt_downloads SET is_bytes = true WHERE timestamp >= @first_is_bytes;
+
+        ALTER TABLE dt_impressions
+        ADD COLUMN is_bytes BOOL,
+        ADD COLUMN listener_session STRING;
+      """,
+      first_is_bytes: @first_is_bytes
+    )
+  end
+end


### PR DESCRIPTION
WOH THERE!  Make sure PRX/analytics-ingest-lambda#86 is deployed and running before doing this.  Otherwise you're going to cause errors.

Actually removes the deprecated columns in "Phase 1: Cleanup Downloads" of [RFC 23](https://github.com/PRX/internal/pull/824).