### PR TITLE
Add feeder feed_slug fields

### DIFF
--- a/priv/big_query/migrations/20220622151925_add_feeder_feeds.exs
+++ b/priv/big_query/migrations/20220622151925_add_feeder_feeds.exs
@@ -1,0 +1,13 @@
+defmodule BigQuery.Migrations.AddFeederFeeds do
+  alias BigQuery.Base.Query
+
+  def up do
+    Query.log("ALTER TABLE dt_downloads ADD COLUMN feeder_feed STRING")
+    Query.log("ALTER TABLE dt_impressions ADD COLUMN feeder_feed STRING")
+  end
+
+  def down do
+    Query.log("ALTER TABLE dt_downloads DROP COLUMN feeder_feed")
+    Query.log("ALTER TABLE dt_impressions DROP COLUMN feeder_feed")
+  end
+end


### PR DESCRIPTION
Adds `feeder_feed` column (naming to match `feeder_podcast` and `feeder_episode`).

I think we want this on both dt_downloads and dt_impressions.

As with all BQ migrations, this must be manually run locally.