### PR TITLE
External integrations BigQuery migration

### DIFF
--- a/priv/big_query/migrations/20230321160811_add_external_ids.exs
+++ b/priv/big_query/migrations/20230321160811_add_external_ids.exs
@@ -1,0 +1,23 @@
+defmodule BigQuery.Migrations.AddExternalIds do
+  alias BigQuery.Base.Query
+
+  def up do
+    Query.log("""
+      ALTER TABLE campaigns ADD COLUMN integration_id INT64;
+      ALTER TABLE campaigns ADD COLUMN external_id STRING;
+
+      ALTER TABLE flights ADD COLUMN integration_id INT64;
+      ALTER TABLE flights ADD COLUMN external_id STRING;
+    """)
+  end
+
+  def down do
+    Query.log("""
+      ALTER TABLE campaigns DROP COLUMN integration_id;
+      ALTER TABLE campaigns DROP COLUMN external_id;
+
+      ALTER TABLE flights DROP COLUMN integration_id;
+      ALTER TABLE flights DROP COLUMN external_id;
+    """)
+  end
+end


### PR DESCRIPTION
Minimal approach for PRX/augury.prx.org#1173.

Just add `integration_id` and `external_id` to the campaigns/flights BQ tables.  That will be enough for us to pull impressions for just those imported-from-external-system flights.