### PR TITLE
Episode feeds

### DIFF
--- a/lib/castle/episode.ex
+++ b/lib/castle/episode.ex
@@ -19,7 +19,8 @@ defmodule Castle.Episode do
     field(:released_at, :utc_datetime)
     field(:segment_count, :integer)
     field(:audio_version, :string)
-    field(:keywords, {:array, :string})
+    field(:categories, {:array, :string})
+    field(:feed_slugs, {:array, :string})
   end
 
   @doc false
@@ -38,7 +39,8 @@ defmodule Castle.Episode do
       :released_at,
       :segment_count,
       :audio_version,
-      :keywords
+      :categories,
+      :feed_slugs
     ])
     |> validate_required([:podcast_id])
   end
@@ -115,7 +117,8 @@ defmodule Castle.Episode do
       released_at: parse_dtim(doc["releasedAt"]),
       segment_count: doc["segmentCount"],
       audio_version: doc["audioVersion"],
-      keywords: doc["categories"]
+      categories: doc["categories"],
+      feed_slugs: doc["feedSlugs"]
     }
   end
 

--- a/priv/big_query/migrations/20240614141751_rename_episode_keywords.exs
+++ b/priv/big_query/migrations/20240614141751_rename_episode_keywords.exs
@@ -1,0 +1,15 @@
+defmodule BigQuery.Migrations.RenameEpisodeKeywords do
+  alias BigQuery.Base.Query
+
+  def up do
+    Query.log("""
+      ALTER TABLE episodes RENAME COLUMN keywords TO categories;
+    """)
+  end
+
+  def down do
+    Query.log("""
+      ALTER TABLE episodes RENAME COLUMN categories TO keywords;
+    """)
+  end
+end

--- a/priv/repo/migrations/20240614140904_rename_episode_keywords.exs
+++ b/priv/repo/migrations/20240614140904_rename_episode_keywords.exs
@@ -1,0 +1,7 @@
+defmodule Castle.Repo.Migrations.RenameEpisodeKeywords do
+  use Ecto.Migration
+
+  def change do
+    rename(table(:episodes), :keywords, to: :categories)
+  end
+end

--- a/priv/repo/migrations/20240614140914_add_episode_feed_slugs.exs
+++ b/priv/repo/migrations/20240614140914_add_episode_feed_slugs.exs
@@ -1,0 +1,9 @@
+defmodule Castle.Repo.Migrations.AddEpisodeFeedSlugs do
+  use Ecto.Migration
+
+  def change do
+    alter table(:episodes) do
+      add(:feed_slugs, {:array, :text})
+    end
+  end
+end

--- a/test/castle/episode_test.exs
+++ b/test/castle/episode_test.exs
@@ -49,6 +49,10 @@ defmodule Castle.EpisodeTest do
       "categories" => [
         "some",
         "tag"
+      ],
+      "feedSlugs" => [
+        "default",
+        "bonus-feed"
       ]
     })
 
@@ -65,7 +69,8 @@ defmodule Castle.EpisodeTest do
     assert_time(episode.released_at, "2018-04-25T04:30:01Z")
     assert episode.segment_count == 2
     assert episode.audio_version == "my-version"
-    assert episode.keywords == ["some", "tag"]
+    assert episode.categories == ["some", "tag"]
+    assert episode.feed_slugs == ["default", "bonus-feed"]
   end
 
   test "updates from a feeder doc" do


### PR DESCRIPTION
Pull Episode feed_slugs from Feeder API.

Also - stop renaming `episode.categories` to `keywords`.  This is some longstanding confusion/annoyance.  I've renamed both the postgres db here and the BigQuery column.