### PR TITLE
Set up feed slugs

### DIFF
--- a/lib/big_query/sync/episodes_task.ex
+++ b/lib/big_query/sync/episodes_task.ex
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Bigquery.Sync.Episodes do
     fields = ~w(
       id podcast_id guid title subtitle image_url
       created_at updated_at published_at released_at deleted_at
-      segment_count audio_version categories season_number episode_number
+      segment_count audio_version categories feed_slugs season_number episode_number
     )
 
     rows = Enum.map(Castle.Episode.all(), &episode_row(&1, fields))

--- a/priv/big_query/migrations/20260202120000_add_feed_slugs_to_episodes.exs
+++ b/priv/big_query/migrations/20260202120000_add_feed_slugs_to_episodes.exs
@@ -1,0 +1,15 @@
+defmodule BigQuery.Migrations.AddFeedSlugsToEpisodes do
+  alias BigQuery.Base.Query
+
+  def up do
+    Query.log("""
+      ALTER TABLE episodes ADD COLUMN feed_slugs ARRAY<STRING>;
+    """)
+  end
+
+  def down do
+    Query.log("""
+      ALTER TABLE episodes DROP COLUMN feed_slugs;
+    """)
+  end
+end


### PR DESCRIPTION
Before https://github.com/PRX/augury.prx.org/issues/1959

This adds `feedSlugs` to the Big Query episodes table and brings that to parity with existing castle episodes schema.