### PR TITLE
Exec app process from bin/application

### DIFF
--- a/bin/application
+++ b/bin/application
@@ -23,13 +23,13 @@ ApplicationRun () {
     ApplicationUsage
     exit
   elif [ "$PROCESS" = "web" ] ; then
-    mix do ecto.migrate, phx.server
+    exec mix do ecto.migrate, phx.server
   elif [ "$PROCESS" = "web-built" ] ; then
-    trap 'exit' INT; /opt/built/bin/castle foreground
+    exec /opt/built/bin/castle foreground
   elif [ "$PROCESS" = "console" ] ; then
-    iex -S mix
+    exec iex -S mix
   elif [ "$PROCESS" = "console-built" ] ; then
-    trap 'exit' INT; /opt/built/bin/castle remote_console
+    exec /opt/built/bin/castle remote_console
   elif [ "$PROCESS" = "test" ] ; then
     CheckDependencies
     mix test
@@ -61,11 +61,11 @@ BuiltRun () {
     exit
   elif [ "$PROCESS" = "web" ] ; then
     /opt/app/bin/castle migrate
-    trap 'exit' INT; /opt/app/bin/castle foreground
+    exec /opt/app/bin/castle foreground
   elif [ "$PROCESS" = "console" ] ; then
-    trap 'exit' INT; /opt/app/bin/castle remote_console
+    exec /opt/app/bin/castle remote_console
   elif [ "$PROCESS" = "--" ] ; then
-    trap 'exit' INT; /opt/app/bin/castle $CMD_ARGS
+    exec /opt/app/bin/castle $CMD_ARGS
   else
     echo "ERROR: $PROCESS is not a valid command."
     BuiltUsage


### PR DESCRIPTION
Multi-repo changeset

bin/application is the container ENTRYPOINT and starts the app as a child process without exec, so the app never receives the SIGTERM that ECS sends on task stop. Where the task definition sets InitProcessEnabled, docker-init forwards SIGTERM only to the wrapper shell, and the app is SIGKILLed when the shell exits. Where it doesn't, the wrapper shell is PID 1, ignores SIGTERM, and the task waits out the full StopTimeout before SIGKILL. Either way there is no graceful shutdown: workers are killed mid-job and web servers never drain.

This execs the selected app process so it receives SIGTERM directly. Callers that previously supplied exec themselves are updated to remove the now-redundant argument.